### PR TITLE
Fix FAS url for groups.

### DIFF
--- a/pkgdb2/templates/packager.html
+++ b/pkgdb2/templates/packager.html
@@ -10,7 +10,11 @@
 <h1>
   {{ packager | avatar | safe }}
   {{ packager }}</h1> (<a class="fas" target="_blank"
-    href="https://admin.fedoraproject.org/accounts/user/view/{{ packager }}"
+    {% if packager.startswith('group::') %}
+        href="https://admin.fedoraproject.org/accounts/group/view/{{ packager.replace('group::', '') }}"
+    {% else %}
+        href="https://admin.fedoraproject.org/accounts/user/view/{{ packager }}"
+    {% endif %}
     >fas</a>)
 </span>
 


### PR DESCRIPTION
This was previously a 404 if the packager displayed was a group.

Signed-off-by: Ricky Elrod ricky@elrod.me
