### PR TITLE
Include the monitoring state in the GET API.

### DIFF
--- a/pkgdb2/lib/model/__init__.py
+++ b/pkgdb2/lib/model/__init__.py
@@ -1473,7 +1473,8 @@ class Package(BASE):
             'status': self.status,
             'review_url': self.review_url,
             'upstream_url': self.upstream_url,
-            'creation_date': time.mktime(self.date_created.timetuple())
+            'creation_date': time.mktime(self.date_created.timetuple()),
+            'monitor': self.monitor,
         }
 
         _seen.append(cls)

--- a/tests/test_flask_api_packages.py
+++ b/tests/test_flask_api_packages.py
@@ -1444,6 +1444,12 @@ class FlaskApiPackagesTest(Modeltests):
         # Works
         user.username = 'pingou'
         with user_set(pkgdb2.APP, user):
+            # Ensure that GETs show that it is *not* monitored
+            output = self.app.get('/api/package/guake/')
+            self.assertEqual(output.status_code, 200)
+            data = json.loads(output.data)
+            self.assertEqual(data['packages'][0]['package']['monitor'], False)
+
             output = self.app.post('/api/package/guake/monitor/1')
             self.assertEqual(output.status_code, 200)
             data = json.loads(output.data)
@@ -1469,6 +1475,12 @@ class FlaskApiPackagesTest(Modeltests):
 
             self.assertEqual(
                 data['output'], "ok")
+
+            # Ensure that subsequent GETs show that it is monitored
+            output = self.app.get('/api/package/guake/')
+            self.assertEqual(output.status_code, 200)
+            data = json.loads(output.data)
+            self.assertEqual(data['packages'][0]['package']['monitor'], True)
 
         # User is not a packager but is admin
         user = FakeFasUserAdmin()


### PR DESCRIPTION
I'd like to use this for the-new-hotness so that when it queries for a
particular package, it can figure out if it should file bugs on that
package or not.
