### PR TITLE
Drop branch from

### DIFF
--- a/pkgdb2/forms.py
+++ b/pkgdb2/forms.py
@@ -371,30 +371,6 @@ class ConfirmationForm(wtf.Form):
     pass
 
 
-class NewRequestForm(BranchForm):
-    """ Form to perform an action on one or more branches of a package. """
-    from_branch = wtforms.SelectField(
-        'Branch from which to create this or these new branches',
-        [wtforms.validators.Required()],
-        choices=[('', '')])
-
-    def __init__(self, *args, **kwargs):
-        """ Calls the default constructor with the normal arguments.
-        Fill the SelectField using the additionnal arguments provided.
-        """
-        super(NewRequestForm, self).__init__(*args, **kwargs)
-        if 'collections' in kwargs:
-            self.branches.choices = [
-                (collec, collec)
-                for collec in kwargs['collections']
-            ]
-        if 'from_branch' in kwargs:
-            self.from_branch.choices = [
-                (collec, collec)
-                for collec in kwargs['from_branch']
-            ]
-
-
 class EditActionStatusForm(wtf.Form):
     """ Form to update the status of an admin action. """
     id = wtforms.TextField(

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -1814,7 +1814,6 @@ def add_new_package_request(
     action = model.AdminAction(
         package_id=None,
         collection_id=clt.id,
-        from_collection_id=None,
         user=user.username,
         _status='Awaiting Review',
         action='request.package',

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -1667,12 +1667,11 @@ def add_branch(session, clt_from, clt_to, user):
     return messages
 
 
-def add_new_branch_request(session, pkg_name, clt_from, clt_to, user):
+def add_new_branch_request(session, pkg_name, clt_to, user):
     """ Register a new branch request.
 
     :arg session: session with which to connect to the database.
     :arg pkg_name: the name of the package for which to create the branch.
-    :arg clt_from: the ``branchname`` of the collection to branch from.
     :arg clt_to: the ``branchname`` of the collection to branch to.
     :arg user: the user making the action.
     :raises pkgdb2.lib.PkgdbException: There are three conditions leading to
@@ -1689,11 +1688,6 @@ def add_new_branch_request(session, pkg_name, clt_from, clt_to, user):
         raise PkgdbException('Package %s not found' % pkg_name)
 
     try:
-        clt_from = model.Collection.by_name(session, clt_from)
-    except NoResultFound:
-        raise PkgdbException('Branch %s not found' % clt_from)
-
-    try:
         clt_to = model.Collection.by_name(session, clt_to)
     except NoResultFound:
         raise PkgdbException('Branch %s not found' % clt_to)
@@ -1707,7 +1701,6 @@ def add_new_branch_request(session, pkg_name, clt_from, clt_to, user):
     action = model.AdminAction(
         package_id=package.id,
         collection_id=clt_to.id,
-        from_collection_id=clt_from.id,
         user=user.username,
         _status=status,
         action='request.branch',
@@ -1722,7 +1715,6 @@ def add_new_branch_request(session, pkg_name, clt_from, clt_to, user):
         message=dict(
             agent=user.username,
             package=package.to_json(acls=False),
-            collection_from=clt_from.to_json(),
             collection_to=clt_to.to_json(),
         )
     )

--- a/pkgdb2/lib/model/__init__.py
+++ b/pkgdb2/lib/model/__init__.py
@@ -1670,11 +1670,6 @@ class AdminAction(BASE):
         index=True)
     user = sa.Column(sa.Text, nullable=False, index=True)
     action = sa.Column(sa.Text, nullable=False, index=True)
-    from_collection_id = sa.Column(
-        sa.Integer,
-        sa.ForeignKey(
-            'Collection.id', ondelete="CASCADE", onupdate="CASCADE"),
-        nullable=True)
     info = sa.Column(sa.Text, nullable=True)
     message = sa.Column(sa.Text, nullable=True)
 
@@ -1696,10 +1691,6 @@ class AdminAction(BASE):
     collection = relation(
         "Collection",
         foreign_keys=[collection_id], remote_side=[Collection.id],
-    )
-    from_collection = relation(
-        "Collection",
-        foreign_keys=[from_collection_id], remote_side=[Collection.id],
     )
 
     @property
@@ -1732,9 +1723,6 @@ class AdminAction(BASE):
         ## pylint complains about timetuple() but it is a method
         # pylint: disable=E1102
 
-        from_collection = None
-        if self.from_collection:
-            from_collection = self.from_collection.to_json()
         pkg = None
         if self.package:
             pkg = self.package.to_json(acls=False)
@@ -1746,7 +1734,6 @@ class AdminAction(BASE):
             'status': self.status,
             'package': pkg,
             'collection': self.collection.to_json(),
-            'from_collection': from_collection,
             'date_created': time.mktime(self.date_created.timetuple()),
             'date_updated': time.mktime(self.date_change.timetuple()),
             'info': self.info_data,

--- a/pkgdb2/lib/utils.py
+++ b/pkgdb2/lib/utils.py
@@ -262,8 +262,7 @@ def log(session, package, topic, message):
                               '%(package_listing.collection.'
                               'branchname)s on package %(package.name)s',
         'package.branch.request': 'user: %(agent)s requested branch: '
-                                 '%(collection_to.branchname)s from branch '
-                                 '%(collection_from.branchname)s '
+                                 '%(collection_to.branchname)s '
                                  'for package %(package.name)s',
         'package.new.request': 'user: %(agent)s request package: '
                                '%(info.pkg_name)s on branch '

--- a/pkgdb2/templates/actions_update.html
+++ b/pkgdb2/templates/actions_update.html
@@ -48,7 +48,6 @@
       </td>
     </tr>
     <tr><td>Action:</td><td>{{ admin_action.action }}</td></tr>
-    <tr><td>From branch:</td><td>{{ admin_action.from_collection.branchname }}</td></tr>
     <tr><td>To branch:</td><td>{{ admin_action.collection.branchname }}</td></tr>
     {{ render_field_in_row(form.status) }}
     {{ render_field_in_row(

--- a/pkgdb2/templates/list_actions.html
+++ b/pkgdb2/templates/list_actions.html
@@ -87,7 +87,6 @@
     <th>Package</th>
     <th>Action</th>
     <th>Branch</th>
-    <th>From branch</th>
     <th>Status</th>
     {% if not select %}
     <th></th>
@@ -118,7 +117,6 @@
     </td>
     <td class="col_odd">{{ action.action }}</td>
     <td>{{ action.collection.branchname }}</td>
-    <td class="col_odd">{{ action.from_collection.branchname }}</td>
     <td class="lastcel" >{{ action.status }}</td>
     {% if not select %}
     <td>

--- a/pkgdb2/templates/request_branch.html
+++ b/pkgdb2/templates/request_branch.html
@@ -23,7 +23,6 @@
     '.package_request_branch', package=package.name, full=full) }}" method="post">
   <table>
     {{ render_field_in_row(form.branches) }}
-    {{ render_field_in_row(form.from_branch) }}
   </table>
   <p class="buttons indent">
     <input type="submit" class="submit positive button" value="Select">

--- a/pkgdb2/ui/packages.py
+++ b/pkgdb2/ui/packages.py
@@ -1089,9 +1089,7 @@ def package_request_branch(package, full=True):
         for collec in collections
         if collec.branchname not in branches]
 
-    form = pkgdb2.forms.NewRequestForm(
-        collections=branches_possible,
-        from_branch=branches)
+    form = pkgdb2.forms.BranchForm(collections=branches_possible)
 
     if form.validate_on_submit():
         for branch in form.branches.data:
@@ -1099,7 +1097,6 @@ def package_request_branch(package, full=True):
                 msg = pkgdblib.add_new_branch_request(
                     session=SESSION,
                     pkg_name=package.name,
-                    clt_from=form.from_branch.data,
                     clt_to=branch,
                     user=flask.g.fas_user)
                 SESSION.commit()

--- a/tests/test_flask_api_admin.py
+++ b/tests/test_flask_api_admin.py
@@ -268,7 +268,6 @@ class FlaskApiAdminTest(Modeltests):
         action = data['actions'][0]
         self.assertEqual(action['action'], "request.branch")
         self.assertEqual(action['id'], 1)
-        self.assertEqual(action['from_collection']['branchname'], 'master')
         self.assertEqual(action['collection']['branchname'], 'el6')
         self.assertEqual(action['package']['name'], 'guake')
         self.assertEqual(action['user'], 'pingou')
@@ -372,7 +371,6 @@ class FlaskApiAdminTest(Modeltests):
         action = data['actions'][0]
         self.assertEqual(action['action'], "request.branch")
         self.assertEqual(action['id'], 1)
-        self.assertEqual(action['from_collection']['branchname'], 'master')
         self.assertEqual(action['collection']['branchname'], 'el6')
         self.assertEqual(action['package']['name'], 'guake')
         self.assertEqual(action['user'], 'pingou')
@@ -409,7 +407,6 @@ class FlaskApiAdminTest(Modeltests):
         action = data['actions'][0]
         self.assertEqual(action['action'], "request.branch")
         self.assertEqual(action['id'], 1)
-        self.assertEqual(action['from_collection']['branchname'], 'master')
         self.assertEqual(action['collection']['branchname'], 'el6')
         self.assertEqual(action['package']['name'], 'guake')
         self.assertEqual(action['user'], 'pingou')

--- a/tests/test_flask_api_admin.py
+++ b/tests/test_flask_api_admin.py
@@ -163,7 +163,7 @@ class FlaskApiAdminTest(Modeltests):
         self.assertEqual(
             sorted(data.keys()),
             ['action', 'collection', 'date_created', 'date_updated',
-             'from_collection', 'id', 'info', 'message', 'output', 'package',
+             'id', 'info', 'message', 'output', 'package',
              'status', 'user'])
         self.assertEqual(data['output'], 'ok')
         self.assertEqual(data['action'], 'request.unretire')
@@ -179,7 +179,7 @@ class FlaskApiAdminTest(Modeltests):
         self.assertEqual(
             sorted(data.keys()),
             ['action', 'collection', 'date_created', 'date_updated',
-             'from_collection', 'id', 'info', 'message', 'output', 'package',
+             'id', 'info', 'message', 'output', 'package',
              'status', 'user'])
         self.assertEqual(data['output'], 'ok')
         self.assertEqual(data['output'], 'ok')

--- a/tests/test_flask_ui_packages.py
+++ b/tests/test_flask_ui_packages.py
@@ -886,24 +886,8 @@ class FlaskUiPackagesTest(Modeltests):
             'csrf_token': csrf_token,
         }
 
-        # Missing one input
-        user = FakeFasUser()
-        user.username = 'kevin'
-        with user_set(pkgdb2.APP, user):
-            output = self.app.post(
-                '/package/guake/request_branch',
-                follow_redirects=True, data=data)
-            self.assertEqual(output.status_code, 200)
-            self.assertTrue(
-                '<td class="errors">Not a valid choice</td>' in output.data)
-
-        data = {
-            'branches': ['el6'],
-            'from_branch': 'master',
-            'csrf_token': csrf_token,
-        }
-
         # Input correct but user is not allowed
+        user.username = 'kevin'
         with user_set(pkgdb2.APP, user):
             output = self.app.post(
                 '/package/guake/request_branch/0',
@@ -915,7 +899,6 @@ class FlaskUiPackagesTest(Modeltests):
 
         data = {
             'branches': ['el6'],
-            'from_branch': 'master',
             'csrf_token': csrf_token,
         }
 

--- a/tests/test_pkgdblib.py
+++ b/tests/test_pkgdblib.py
@@ -1760,7 +1760,6 @@ class PkgdbLibtests(Modeltests):
             pkgdblib.add_new_branch_request,
             session=self.session,
             pkg_name='foobar',
-            clt_from='master',
             clt_to='el6',
             user=FakeFasUserAdmin()
         )
@@ -1771,7 +1770,6 @@ class PkgdbLibtests(Modeltests):
             pkgdblib.add_new_branch_request,
             session=self.session,
             pkg_name='guake',
-            clt_from='master',
             clt_to='foobar',
             user=FakeFasUserAdmin()
         )
@@ -1782,7 +1780,6 @@ class PkgdbLibtests(Modeltests):
             pkgdblib.add_new_branch_request,
             session=self.session,
             pkg_name='guake',
-            clt_from='foobar',
             clt_to='el6',
             user=FakeFasUserAdmin()
         )
@@ -1793,7 +1790,6 @@ class PkgdbLibtests(Modeltests):
         pkgdblib.add_new_branch_request(
             session=self.session,
             pkg_name='guake',
-            clt_from='master',
             clt_to='el6',
             user=user
         )
@@ -1841,7 +1837,6 @@ class PkgdbLibtests(Modeltests):
             pkgdblib.add_new_branch_request(
                 session=self.session,
                 pkg_name='guake',
-                clt_from='master',
                 clt_to='el6',
                 user=FakeFasUser()
             )
@@ -1868,7 +1863,6 @@ class PkgdbLibtests(Modeltests):
             self.assertEqual(actions[0].user, 'pingou')
             self.assertEqual(actions[0].package.name, 'guake')
             self.assertEqual(actions[0].collection.branchname, 'el6')
-            self.assertEqual(actions[0].from_collection.branchname, 'master')
 
     def test_get_admin_action(self):
         """ Test the get_admin_action method of pkgdblib. """
@@ -1887,7 +1881,6 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(action.status, 'Pending')
         self.assertEqual(action.package.name, 'guake')
         self.assertEqual(action.collection.branchname, 'el6')
-        self.assertEqual(action.from_collection.branchname, 'master')
         self.assertEqual(action.info, None)
 
         action = pkgdblib.get_admin_action(self.session, 2)
@@ -1910,7 +1903,6 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(action.status, 'Pending')
         self.assertEqual(action.package.name, 'guake')
         self.assertEqual(action.collection.branchname, 'el6')
-        self.assertEqual(action.from_collection.branchname, 'master')
         self.assertEqual(action.info, None)
 
         self.assertRaises(
@@ -2000,7 +1992,6 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(action.status, 'Approved')
         self.assertEqual(action.package.name, 'guake')
         self.assertEqual(action.collection.branchname, 'el6')
-        self.assertEqual(action.from_collection.branchname, 'master')
         self.assertEqual(action.info, None)
 
     @patch('pkgdb2.lib.utils.get_packagers')


### PR DESCRIPTION
When requesting a new branch we used to asked from which branch this new branch should be created.
However, the way we automated things, we cannot specify to the script from which branch to create the new one, instead we create the new branch pointing it to the first commit in the repo.

So there is no longer need for us to store this information in the DB nor to display it.