### PR TITLE
Warn users about invalid FAS email / bugzilla account mapping

### DIFF
--- a/pkgdb2/default_config.py
+++ b/pkgdb2/default_config.py
@@ -117,3 +117,39 @@ APPLICATION_ROOT = '/'
 # Anitya settings
 PKGDB2_ANITYA_DISTRO='Fedora'
 PKGDB2_ANITYA_URL='https://release-monitoring.org'
+
+
+# PkgDB sync bugzilla email
+PKGDB_SYNC_BUGZILLA_EMAIL = """Greetings.
+
+You are receiving this email because there's a problem with your
+bugzilla.redhat.com account.
+
+If you recently changed the email address associated with your
+Fedora account in the Fedora Account System, it is now out of sync
+with your bugzilla.redhat.com account. This leads to problems
+with Fedora packages you own or are CC'ed on bug reports for.
+
+Please take one of the following actions:
+
+a) login to your old bugzilla.redhat.com account and change the email
+address to match your current email in the Fedora account system.
+https://bugzilla.redhat.com login, click preferences, account
+information and enter new email address.
+
+b) Create a new account in bugzilla.redhat.com to match your
+email listed in your Fedora account system account.
+https://bugzilla.redhat.com/ click 'new account' and enter email
+address.
+
+c) Change your Fedora Account System email to match your existing
+bugzilla.redhat.com account.
+https://admin.fedoraproject.org/accounts login, click on 'my account',
+then 'edit' and change your email address.
+
+If you have questions or concerns, please let us know.
+
+Your prompt attention in this matter is appreciated.
+
+The Fedora admins.
+"""

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -347,7 +347,7 @@ Your prompt attention in this matter is appreciated.
 
 The Fedora admins.
 """
-    data = None
+    data = {}
     if os.path.exists(DATA_CACHE):
         try:
             with open(DATA_CACHE) as stream:
@@ -364,7 +364,7 @@ The Fedora admins.
             now = datetime.datetime.utcnow()
 
             # See if we already know about this user
-            if data and user_email in data and data[user_email]['last_update']:
+            if user_email in data and data[user_email]['last_update']:
                 last_update = datetime.datetime.fromtimestamp(
                     int(data[user_email]['last_update']))
                 # Only notify users once per hour

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -333,7 +333,7 @@ if __name__ == '__main__':
     for product in acls.keys():
         if product not in ('Fedora', 'Fedora EPEL'):
             continue
-        for pkg in acls[product]:
+        for pkg in sorted(acls[product]):
             if DRY_RUN:
                 print pkg
             pkgInfo = acls[product][pkg]

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -364,8 +364,10 @@ if __name__ == '__main__':
 
     # Send notification of errors
     if errors:
-        #print '[DEBUG]', '\n'.join(errors)
-        send_email(
+        if DRY_RUN:
+            print '[DEBUG]', '\n'.join(errors)
+        else:
+            send_email(
                 EMAIL_FROM,
                 NOTIFYEMAIL,
                 'Errors while syncing bugzilla with the PackageDB',

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -362,7 +362,7 @@ if __name__ == '__main__':
             except xmlrpclib.Error, e:
                 # An error occurred in the xmlrpc call.  Shouldn't happen but
                 # we better see what it is
-                errors.append(str(e.args))
+                errors.append('%s -- %s' % (pkg, e.args[-1]))
 
     # Send notification of errors
     if errors:

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -314,39 +314,12 @@ def notify_users(errors):
     ''' Browse the list of errors and when we can retrieve the email
     address, use it to notify the user about the issue.
     '''
-    tmpl_email = """Greetings.
+    tmpl_email = pkgdb2.APP.config.get('PKGDB_SYNC_BUGZILLA_EMAIL', None)
+    if not tmpl_email:
+        print 'No template email configured in the configuration file, '\
+            'no notification sent to the users'
+        return
 
-You are receiving this email because there's a problem with your
-bugzilla.redhat.com account.
-
-If you recently changed the email address associated with your
-Fedora account in the Fedora Account System, it is now out of sync
-with your bugzilla.redhat.com account. This leads to problems
-with Fedora packages you own or are CC'ed on bug reports for.
-
-Please take one of the following actions:
-
-a) login to your old bugzilla.redhat.com account and change the email
-address to match your current email in the Fedora account system.
-https://bugzilla.redhat.com login, click preferences, account
-information and enter new email address.
-
-b) Create a new account in bugzilla.redhat.com to match your
-email listed in your Fedora account system account.
-https://bugzilla.redhat.com/ click 'new account' and enter email
-address.
-
-c) Change your Fedora Account System email to match your existing
-bugzilla.redhat.com account.
-https://admin.fedoraproject.org/accounts login, click on 'my account',
-then 'edit' and change your email address.
-
-If you have questions or concerns, please let us know.
-
-Your prompt attention in this matter is appreciated.
-
-The Fedora admins.
-"""
     data = {}
     if os.path.exists(DATA_CACHE):
         try:

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -370,6 +370,8 @@ The Fedora admins.
                 # Only notify users once per hour
                 if (now - last_update).seconds >= 3600:
                     notify_user = True
+                else:
+                    new_data[user_email] = data[user_email]
             elif not data or user_email not in data:
                 notify_user = True
 

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -289,7 +289,7 @@ class Bugzilla(object):
                     raise
 
 
-def send_email(fromAddress, toAddress, subject, message):
+def send_email(fromAddress, toAddress, subject, message, ccAddress=None):
     '''Send an email if there's an error.
 
     This will be replaced by sending messages to a log later.
@@ -298,6 +298,8 @@ def send_email(fromAddress, toAddress, subject, message):
     msg.add_header('To', ','.join(toAddress))
     msg.add_header('From', fromAddress)
     msg.add_header('Subject', subject)
+    if ccAddress is not None:
+        msg.add_header('Cc', ','.join(ccAddress))
     msg.set_payload(message)
     smtp = smtplib.SMTP('bastion')
     smtp.sendmail(fromAddress, toAddress, msg.as_string())

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -353,7 +353,8 @@ The Fedora admins.
             with open(DATA_CACHE) as stream:
                 data = json.load(stream)
         except Exception as err:
-            print 'Could not read the json file', err
+            print 'Could not read the json file at %s: \nError:  %s' % (
+                DATA_CACHE, err)
 
     new_data = {}
     for error in errors:

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -70,17 +70,22 @@ NOTIFYEMAIL = pkgdb2.APP.config.get('PKGDB2_BUGZILLA_NOTIFY_EMAIL')
 PKGDBSERVER = pkgdb2.APP.config.get('SITE_URL')
 DRY_RUN = pkgdb2.APP.config.get('PKGDB2_BUGZILLA_DRY_RUN', False)
 
+EMAIL_FROM = 'accounts@fedoraproject.org'
+
 # When querying for current info, take segments of 1000 packages a time
 BZ_PKG_SEGMENT = 1000
+
 
 class DataChangedError(Exception):
     '''Raised when data we are manipulating changes while we're modifying it.'''
     pass
 
+
 def segment(iterable, chunk, fill=None):
     '''Collect data into `chunk` sized block'''
     args = [iter(iterable)] * chunk
     return itertools.izip_longest(*args, fillvalue=fill)
+
 
 class ProductCache(dict):
     def __init__(self, bz, acls):
@@ -360,7 +365,8 @@ if __name__ == '__main__':
     # Send notification of errors
     if errors:
         #print '[DEBUG]', '\n'.join(errors)
-        send_email('accounts@fedoraproject.org',
+        send_email(
+                EMAIL_FROM,
                 NOTIFYEMAIL,
                 'Errors while syncing bugzilla with the PackageDB',
 '''

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -32,9 +32,12 @@ __requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
 import pkg_resources
 
 import argparse
+import datetime
+import time
 import sys
 import os
 import itertools
+import json
 import xmlrpclib
 import codecs
 import smtplib
@@ -71,6 +74,7 @@ PKGDBSERVER = pkgdb2.APP.config.get('SITE_URL')
 DRY_RUN = pkgdb2.APP.config.get('PKGDB2_BUGZILLA_DRY_RUN', False)
 
 EMAIL_FROM = 'accounts@fedoraproject.org'
+DATA_CACHE = '/var/tmp/pkgdb_sync_bz.json'
 
 # When querying for current info, take segments of 1000 packages a time
 BZ_PKG_SEGMENT = 1000
@@ -306,6 +310,87 @@ def send_email(fromAddress, toAddress, subject, message, ccAddress=None):
     smtp.quit()
 
 
+def notify_users(errors):
+    ''' Browse the list of errors and when we can retrieve the email
+    address, use it to notify the user about the issue.
+    '''
+    tmpl_email = """Greetings.
+
+You are receiving this email because there's a problem with your
+bugzilla.redhat.com account.
+
+If you recently changed the email address associated with your
+Fedora account in the Fedora Account System, it is now out of sync
+with your bugzilla.redhat.com account. This leads to problems
+with Fedora packages you own or are CC'ed on bug reports for.
+
+Please take one of the following actions:
+
+a) login to your old bugzilla.redhat.com account and change the email
+address to match your current email in the Fedora account system.
+https://bugzilla.redhat.com login, click preferences, account
+information and enter new email address.
+
+b) Create a new account in bugzilla.redhat.com to match your
+email listed in your Fedora account system account.
+https://bugzilla.redhat.com/ click 'new account' and enter email
+address.
+
+c) Change your Fedora Account System email to match your existing
+bugzilla.redhat.com account.
+https://admin.fedoraproject.org/accounts login, click on 'my account',
+then 'edit' and change your email address.
+
+If you have questions or concerns, please let us know.
+
+Your prompt attention in this matter is appreciated.
+
+The Fedora admins.
+"""
+    data = None
+    if os.path.exists(DATA_CACHE):
+        try:
+            with open(DATA_CACHE) as stream:
+                data = json.load(stream)
+        except Exception as err:
+            print 'Could not read the json file', err
+
+    new_data = {}
+    for error in errors:
+        notify_user = False
+        if 'The name ' in error and ' is not a valid username' in error:
+            user_email = error.split(' is not a valid username')[0].split(
+                'The name ')[1].strip()
+            now = datetime.datetime.utcnow()
+
+            # See if we already know about this user
+            if data and user_email in data and data[user_email]['last_update']:
+                last_update = datetime.datetime.fromtimestamp(
+                    int(data[user_email]['last_update']))
+                # Only notify users once per hour
+                if (now - last_update).seconds >= 3600:
+                    notify_user = True
+            elif not data or user_email not in data:
+                notify_user = True
+
+            if notify_user:
+                send_email(
+                    EMAIL_FROM,
+                    [user_email],
+                    subject='Please fix your bugzilla.redhat.com account',
+                    message=tmpl_email,
+                    ccAddress=NOTIFYEMAIL,
+                )
+
+                new_data[user_email] = {
+                    'last_update': time.mktime(now.timetuple())
+                }
+
+    if new_data:
+        with open(DATA_CACHE, 'w') as stream:
+            json.dump(new_data, stream)
+
+
 if __name__ == '__main__':
     sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 
@@ -369,6 +454,7 @@ if __name__ == '__main__':
         if DRY_RUN:
             print '[DEBUG]', '\n'.join(errors)
         else:
+            notify_users(errors)
             send_email(
                 EMAIL_FROM,
                 NOTIFYEMAIL,

--- a/utility/pkgdb-sync-bugzilla
+++ b/utility/pkgdb-sync-bugzilla
@@ -386,9 +386,8 @@ The Fedora admins.
                     'last_update': time.mktime(now.timetuple())
                 }
 
-    if new_data:
-        with open(DATA_CACHE, 'w') as stream:
-            json.dump(new_data, stream)
+    with open(DATA_CACHE, 'w') as stream:
+        json.dump(new_data, stream)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently admins are getting an email every 10 minutes informing them about invalid mappings. Then, we email the users so that they can act on it.

With this change, users will be automatically notified.

Sometime, it takes a really long time for users to react, recently we have seen more than a week. So while we do not want to spam users as much as we do for admins (every 10 minutes), we still want to pressure them into fixing it by sending them a hourly reminder.