### PR TITLE
Do not automatically update branch where the user is Approved

### DIFF
--- a/pkgdb2/templates/acl_update.html
+++ b/pkgdb2/templates/acl_update.html
@@ -110,10 +110,13 @@ $(function(){
         var _val = $(this).children(':selected').val();
         var row = $(this).parent().parent();
         row.children().each(function() {
-            $(this).children().children(
-                'option:contains(' + _val + ')').prop({selected: true});
-            var _val_lbl = _val.replace(' ', '_');
-            $(this).children().attr('class', '').addClass(_val_lbl);
+            var _item = $(this).children();
+            if (_item.val() != 'Approved') {
+                _item.children('option:contains(' + _val + ')').prop(
+                    {selected: true});
+                var _val_lbl = _val.replace(' ', '_');
+                _item.attr('class', '').addClass(_val_lbl);
+            }
         });
     });
 });

--- a/pkgdb2/templates/list_actions.html
+++ b/pkgdb2/templates/list_actions.html
@@ -133,7 +133,7 @@
 {% endfor %}
 </table>
 {% else %}
-<p>No requests found for this user</p>
+<p>No actions found</p>
 {% endif %}
 
 {% endblock %}

--- a/tests/test_flask_ui_admin.py
+++ b/tests/test_flask_ui_admin.py
@@ -141,7 +141,7 @@ class FlaskUiAdminTest(Modeltests):
                 'Restrict to package: <input type="text" name="package" />'
                 in output.data)
             self.assertTrue(
-                '<p>No requests found for this user</p>' in output.data)
+                '<p>No actions found</p>' in output.data)
 
     @patch('pkgdb2.fas_login_required')
     def test_admin_action_edit_status(self, login_func):


### PR DESCRIPTION
This fixes the situation where the user ask for a Fedora branch (ie:
put the status to `Awaiting Review`) while he/she already has the ACL
on for example EPEL branches.
With the current behavior, all branches would be set to `Awaiting Review`
effectively leading to the user loosing the already Approved ACLs.
With this commit `Approved` ACLs are not automatically updated.

Fixes https://fedorahosted.org/pkgdb2/ticket/44