### PR TITLE
Fix 'undefined' when clicking monitor toggle.

### DIFF
--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -606,10 +606,14 @@ confusing what the difference is between that status an the per-branch status)
     $(function(){
         $("#committers").tablesorter();
 
+        {% if not(g.fas_user.username in admins
+                  or g.fas_user.username in commiters
+                  or is_admin) %}
         $('#monitor_lbl').click(function(){
             var _mon = $('#monitor');
             toggle_monitor(!_mon[0].checked);
         });
+        {% endif %}
 
         $('#givebutton').click(function(){
             var _url = "{{


### PR DESCRIPTION
When you click the monitoring toggle and you are not logged in, it makes
the request anyway and then appends "undefined" to the page. This looks
tacky. Instead, if we don't get a response back, just bail out and do
nothing.

Signed-off-by: Ricky Elrod <ricky@elrod.me>