### PR TITLE
Retired pkgs

### DIFF
--- a/pkgdb2/api/__init__.py
+++ b/pkgdb2/api/__init__.py
@@ -121,6 +121,7 @@ def api():
     api_extras_pendingacls = load_doc(extras.api_pendingacls)
     api_extras_api_groups = load_doc(extras.api_groups)
     api_extras_monitored = load_doc(extras.api_monitored)
+    api_extras_retired = load_doc(extras.api_retired)
 
     return flask.render_template(
         'api.html',
@@ -153,7 +154,8 @@ def api():
             api_extras_bugzilla, api_extras_critpath,
             api_extras_notify, api_extras_notify_all,
             api_extras_vcs, api_extras_pendingacls,
-            api_extras_api_groups, api_extras_monitored
+            api_extras_api_groups, api_extras_monitored,
+            api_extras_retired
         ]
     )
 

--- a/pkgdb2/api/extras.py
+++ b/pkgdb2/api/extras.py
@@ -605,7 +605,8 @@ def api_retired():
 
         /api/retired
 
-    :kwarg collection: Either Fedora or EPEL (default: Fedora)
+    :kwarg collection: Either `Fedora` or `Fedora EPEL` or any other
+        collection name (default: Fedora)
     :kwarg format: Specify if the output is text or json (default: text).
 
     '''

--- a/pkgdb2/api/extras.py
+++ b/pkgdb2/api/extras.py
@@ -590,3 +590,53 @@ def api_dead_package(pkg_name, clt_name):
         content_type="text/plain;charset=UTF-8",
         status=req.status_code,
     )
+
+
+@API.route('/retired/')
+@API.route('/retired')
+def api_retired():
+    '''
+    List packages retired
+    ---------------------
+    Return the list of packages in pkgdb that have been retired on all
+    Fedora or EPEL collections.
+
+    ::
+
+        /api/retired
+
+    :kwarg collection: Either Fedora or EPEL (default: Fedora)
+    :kwarg format: Specify if the output is text or json (default: text).
+
+    '''
+
+    collection = flask.request.args.get('collection', 'Fedora')
+    out_format = flask.request.args.get('format', 'text')
+
+    if out_format not in ('text', 'json'):
+        out_format = 'text'
+
+    if request_wants_json():
+        out_format = 'json'
+
+    output = {}
+
+    pkgs = pkgdblib.get_retired_packages(SESSION, collection=collection)
+
+    if out_format == 'json':
+        output = {
+            "packages": [pkg.name for pkg in pkgs],
+            "total_packages": len(pkgs),
+            "collection": collection,
+        }
+        return flask.jsonify(output)
+    else:
+        output = [
+            "# Number of packages: %s" % len(pkgs),
+            "# collection: %s" % collection]
+        for pkg in pkgs:
+            output.append("%s" % (pkg.name))
+        return flask.Response(
+            '\n'.join(output),
+            content_type="text/plain;charset=UTF-8"
+        )

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -2404,3 +2404,17 @@ def edit_action_status(
         msg = 'Nothing to change.'
 
     return msg
+
+
+def get_retired_packages(session, collection):
+    """ Return the list of packaged retired on all active collections
+    belonging to the collectin specified.
+
+    :arg session: the session with which to connect to the database.
+    :arg collection: the collection name to filter the package retired.
+    :returns: a list of Package.
+    :rtype: list()
+
+    """
+
+    return model.Package.get_retired(session, collection)

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -2251,7 +2251,7 @@ def get_monitored_package(session):
     """ Return the list of packaged flag as `to monitor`.
 
     :arg session: the session with which to connect to the database.
-    :returns: a list of Ppackage.
+    :returns: a list of Package.
     :rtype: list()
 
     """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -702,6 +702,74 @@ def create_admin_actions(session):
     session.commit()
 
 
+def create_retired_pkgs(session):
+    """ Add some retired packages. """
+    create_collection(session)
+    create_package(session)
+
+    guake_pkg = model.Package.by_name(session, 'guake')
+    fedocal_pkg = model.Package.by_name(session, 'fedocal')
+    geany_pkg = model.Package.by_name(session, 'geany')
+    offlineimap_pkg = model.Package.by_name(session, 'offlineimap')
+
+    f17_collec = model.Collection.by_name(session, 'f17')
+    f18_collec = model.Collection.by_name(session, 'f18')
+    devel_collec = model.Collection.by_name(session, 'master')
+    el4_collec = model.Collection.by_name(session, 'el4')
+    el6_collec = model.Collection.by_name(session, 'el6')
+
+    # Pkg: guake - Collection: EL4 - Approved
+    pkgltg = model.PackageListing(
+        point_of_contact='pingou',
+        status='Approved',
+        package_id=guake_pkg.id,
+        collection_id=el4_collec.id,
+    )
+    session.add(pkgltg)
+    # Pkg: guake - Collection: EL6 - Retired
+    pkgltg = model.PackageListing(
+        point_of_contact='pingou',
+        status='Retired',
+        package_id=guake_pkg.id,
+        collection_id=el6_collec.id,
+    )
+    session.add(pkgltg)
+    # Pkg: guake - Collection: devel - Approved
+    pkgltg = model.PackageListing(
+        point_of_contact='pingou',
+        status='Approved',
+        package_id=guake_pkg.id,
+        collection_id=devel_collec.id,
+    )
+    session.add(pkgltg)
+
+    # Pkg: fedocal - Collection: F17 - Retired
+    pkgltg = model.PackageListing(
+        point_of_contact='pingou',
+        status='Retired',
+        package_id=fedocal_pkg.id,
+        collection_id=f17_collec.id,
+    )
+    session.add(pkgltg)
+    # Pkg: fedocal - Collection: F18 - Retired
+    pkgltg = model.PackageListing(
+        point_of_contact='orphan',
+        status='Retired',
+        package_id=fedocal_pkg.id,
+        collection_id=f18_collec.id,
+    )
+    session.add(pkgltg)
+    # Pkg: fedocal - Collection: devel - Retired
+    pkgltg = model.PackageListing(
+        point_of_contact='orphan',
+        status='Retired',
+        package_id=fedocal_pkg.id,
+        collection_id=devel_collec.id,
+    )
+    session.add(pkgltg)
+    session.commit()
+
+
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(Modeltests)
     unittest.TextTestRunner(verbosity=2).run(SUITE)


### PR DESCRIPTION
This adds a new API endpoint listing all the packages retired in every active branch of a specified collection (defaults to: Fedora).

This should fix https://github.com/fedora-infra/pkgdb2/issues/59 for now as there is currently no way to call bugzilla's API to do it automatically.

And fixes https://github.com/fedora-infra/pkgdb2/issues/179