### PR TITLE
Fix a typo in the list_actions template.

### DIFF
--- a/pkgdb2/templates/list_actions.html
+++ b/pkgdb2/templates/list_actions.html
@@ -58,7 +58,8 @@
     <tr>
         <td>
         {% if page > 1%}
-            <a href="{{ url_for('.admin_actions') }}?page={{page - 1}}&package={{package}}&from_date={{from_date}}">
+            <a href="{{ url_for('.admin_actions', page=page-1,
+                package=package, from_date=from_date) }}">
                 < Previous
             </a>
         {% else %}
@@ -68,7 +69,8 @@
         <td>{{ page }} / {{ total_page }}</td>
         <td>
             {% if page < total_page %}
-            <a href="{{ url_for('.admin_actions') }}?page={{page + 1}}&package={{package}}&from_date={{from_date}}">
+            <a href="{{ url_for('.admin_actions', page=page+1,
+                package=package, from_date=from_date) }}">
                 Next >
             </a>
             {% else %}

--- a/pkgdb2/templates/list_actions.html
+++ b/pkgdb2/templates/list_actions.html
@@ -58,7 +58,7 @@
     <tr>
         <td>
         {% if page > 1%}
-            <a href="{{ url_for('.admin_action') }}?page={{page - 1}}&package={{package}}&from_date={{from_date}}">
+            <a href="{{ url_for('.admin_actions') }}?page={{page - 1}}&package={{package}}&from_date={{from_date}}">
                 < Previous
             </a>
         {% else %}
@@ -68,7 +68,7 @@
         <td>{{ page }} / {{ total_page }}</td>
         <td>
             {% if page < total_page %}
-            <a href="{{ url_for('.admin_action') }}?page={{page + 1}}&package={{package}}&from_date={{from_date}}">
+            <a href="{{ url_for('.admin_actions') }}?page={{page + 1}}&package={{package}}&from_date={{from_date}}">
                 Next >
             </a>
             {% else %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -684,7 +684,7 @@ def create_package_acl2(session):
     session.commit()
 
 
-def create_admin_actions(session):
+def create_admin_actions(session, n=1):
     """ Add an Admin Actions for the tests. """
     guake_pkg = model.Package.by_name(session, 'guake')
     el6_collec = model.Collection.by_name(session, 'el6')
@@ -698,6 +698,20 @@ def create_admin_actions(session):
     )
 
     session.add(action)
+
+    if n > 1:
+        f17_collec = model.Collection.by_name(session, 'f17')
+
+        action = model.AdminAction(
+            package_id=guake_pkg.id,
+            collection_id=f17_collec.id,
+            user='ralph',
+            _status='Pending',
+            action='request.branch',
+        )
+
+        session.add(action)
+
 
     session.commit()
 

--- a/tests/test_flask_ui_admin.py
+++ b/tests/test_flask_ui_admin.py
@@ -36,7 +36,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(
     os.path.abspath(__file__)), '..'))
 
 import pkgdb2
-from tests import (Modeltests, FakeFasUser, FakeFasUserAdmin, user_set)
+from tests import (
+    Modeltests, FakeFasUser, FakeFasUserAdmin, user_set,
+    create_collection, create_package, create_admin_actions,
+)
 
 
 class FlaskUiAdminTest(Modeltests):
@@ -47,6 +50,7 @@ class FlaskUiAdminTest(Modeltests):
         super(FlaskUiAdminTest, self).setUp()
 
         pkgdb2.APP.config['TESTING'] = True
+        pkgdb2.APP.config['ITEMS_PER_PAGE'] = 1
         pkgdb2.SESSION = self.session
         pkgdb2.ui.SESSION = self.session
         pkgdb2.ui.acls.SESSION = self.session
@@ -142,6 +146,21 @@ class FlaskUiAdminTest(Modeltests):
                 in output.data)
             self.assertTrue(
                 '<p>No actions found</p>' in output.data)
+
+            # Create some actions to see
+            create_collection(pkgdb2.SESSION)
+            create_package(pkgdb2.SESSION)
+            create_admin_actions(pkgdb2.SESSION, n=2)
+
+            output = self.app.get('/admin/actions/?status=all')
+            self.assertEqual(output.status_code, 200)
+            self.assertTrue('<h1>Actions</h1>' in output.data)
+            self.assertTrue(
+                'Restrict to package: <input type="text" name="package" />'
+                in output.data)
+            # 2 actions = 2 pages
+            self.assertTrue('<td>1 / 2</td>' in output.data)
+
 
     @patch('pkgdb2.fas_login_required')
     def test_admin_action_edit_status(self, login_func):

--- a/tests/test_flask_ui_admin.py
+++ b/tests/test_flask_ui_admin.py
@@ -50,7 +50,6 @@ class FlaskUiAdminTest(Modeltests):
         super(FlaskUiAdminTest, self).setUp()
 
         pkgdb2.APP.config['TESTING'] = True
-        pkgdb2.APP.config['ITEMS_PER_PAGE'] = 1
         pkgdb2.SESSION = self.session
         pkgdb2.ui.SESSION = self.session
         pkgdb2.ui.acls.SESSION = self.session
@@ -152,6 +151,10 @@ class FlaskUiAdminTest(Modeltests):
             create_package(pkgdb2.SESSION)
             create_admin_actions(pkgdb2.SESSION, n=2)
 
+            # set the pagination
+            pkgdb2.APP.config['ITEMS_PER_PAGE'] = 1
+
+            # Check the list
             output = self.app.get('/admin/actions/?status=all')
             self.assertEqual(output.status_code, 200)
             self.assertTrue('<h1>Actions</h1>' in output.data)
@@ -160,6 +163,9 @@ class FlaskUiAdminTest(Modeltests):
                 in output.data)
             # 2 actions = 2 pages
             self.assertTrue('<td>1 / 2</td>' in output.data)
+
+            # Reset the pagination
+            pkgdb2.APP.config['ITEMS_PER_PAGE'] = 50
 
 
     @patch('pkgdb2.fas_login_required')


### PR DESCRIPTION
The endpoints is called ``admin_actions`` plural not ``admin_action``
singular.  This was causing a BuildError 500 in production when it tried
to display pagination.