### PR TITLE
Rework the package request pages

### DIFF
--- a/pkgdb2/templates/actions_update.html
+++ b/pkgdb2/templates/actions_update.html
@@ -21,10 +21,10 @@
 {% endif %}
 {% if tag %}
 <p>
-    During these 7 days, you can 'Block' the new branch process by setting
-    the request to <span class="italic bold">Blocked</span> or 'Approve' it by
-    setting it to <span class="italic bold">Awaiting Review</span> to inform
-    admins that they can now review this request.
+    During the 7 days following the request, you can 'Block' the new branch
+    process by setting the request to <span class="italic bold">Blocked</span>
+    or 'Approve' it by setting it to <span class="italic bold">Awaiting Review</span>
+    to inform admins that they can now review this request.
 </p>
 <form action="{{ url_for('.package_request_edit',
                 package=package.name or None, action_id=action_id) }}"

--- a/pkgdb2/templates/actions_update.html
+++ b/pkgdb2/templates/actions_update.html
@@ -20,12 +20,14 @@
 </p>
 {% endif %}
 {% if tag %}
+{% if admin_action.action != 'request.package' %}
 <p>
     During the 7 days following the request, you can 'Block' the new branch
     process by setting the request to <span class="italic bold">Blocked</span>
     or 'Approve' it by setting it to <span class="italic bold">Awaiting Review</span>
     to inform admins that they can now review this request.
 </p>
+{% endif %}
 <form action="{{ url_for('.package_request_edit',
                 package=package.name or None, action_id=action_id) }}"
     method="post">

--- a/pkgdb2/templates/actions_update_ro.html
+++ b/pkgdb2/templates/actions_update_ro.html
@@ -24,7 +24,6 @@
     </td>
   </tr>
   <tr><td>Action:</td><td>{{ admin_action.action }}</td></tr>
-  <tr><td>From branch:</td><td>{{ admin_action.from_collection.branchname }}</td></tr>
   <tr><td>To branch:</td><td>{{ admin_action.collection.branchname }}</td></tr>
   <tr><td>Status</td><td>{{ admin_action.status }}</td></tr>
 <tr><td>Message</td><td>{{ admin_action.message }}</td></tr>

--- a/pkgdb2/ui/packages.py
+++ b/pkgdb2/ui/packages.py
@@ -349,7 +349,6 @@ def package_anitya(package, full=True):
 
 
 @UI.route('/package/requests/<action_id>', methods=['GET', 'POST'])
-@packager_login_required
 def package_request_edit(action_id):
     """ Edit an Admin Action status
     """
@@ -364,6 +363,13 @@ def package_request_edit(action_id):
         package = admin_action.package.name
 
     if admin_action.status in ['Accepted', 'Blocked', 'Denied']:
+        return flask.render_template(
+            'actions_update_ro.html',
+            admin_action=admin_action,
+            action_id=action_id,
+        )
+
+    if not is_authenticated() or not 'packager' in flask.g.fas_user.groups:
         return flask.render_template(
             'actions_update_ro.html',
             admin_action=admin_action,

--- a/pkgdb2/ui/packages.py
+++ b/pkgdb2/ui/packages.py
@@ -393,7 +393,7 @@ def package_request_edit(action_id):
     action_status = ['Pending', 'Awaiting Review', 'Blocked']
     if admin_action.user == flask.g.fas_user.username:
         action_status = ['Pending', 'Obsolete']
-        if pkg_admin:
+        if pkg_admin or admin_action.action == 'request.package':
             action_status.append('Awaiting Review')
 
     form = pkgdb2.forms.EditActionStatusForm(

--- a/tests/test_flask_ui_packages.py
+++ b/tests/test_flask_ui_packages.py
@@ -913,6 +913,29 @@ class FlaskUiPackagesTest(Modeltests):
                 '<li class="message">Branch el6 requested for user pingou</'
                 in output.data)
 
+        # Check the request authenticated
+        user = FakeFasUser()
+        with user_set(pkgdb2.APP, user):
+            output = self.app.get('/package/requests/1')
+            self.assertEqual(output.status_code, 200)
+            self.assertTrue('<h1>Update request: 1</h1>' in output.data)
+            self.assertTrue(
+                'As current admin of the package  you have the possibility'
+                in output.data)
+            self.assertTrue(
+                '<form action="/package/requests/1"' in output.data)
+
+        # Check the request un-authenticated
+        with user_set(pkgdb2.APP, None):
+            output = self.app.get('/package/requests/1')
+            self.assertEqual(output.status_code, 200)
+            self.assertTrue('<h1>Request: 1</h1>' in output.data)
+            self.assertFalse(
+                'As current admin of the package  you have the possibility'
+                in output.data)
+            self.assertFalse(
+                '<form action="/package/requests/1"' in output.data)
+
     @patch('pkgdb2.lib.utils.get_packagers')
     @patch('pkgdb2.packager_login_required')
     def test_package_request_new(self, login_func, mock_func):


### PR DESCRIPTION
* Provide a read-only page describing the request
* Rework the package request pages
* Add unit-tests