### PR TITLE
Fix koschei info in the package page

### DIFF
--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -97,8 +97,7 @@ confusing what the difference is between that status an the per-branch status)
               <label class="switch">
                 <input type="checkbox" class="switch-input" name="koschei" id="koschei"
                   {%if package.koschei %}checked="checked"{% endif %}
-                  {% if not(g.fas_user.username in admins
-                            or g.fas_user.username in commiters
+                  {% if not('packager' in g.fas_user.groups
                             or is_admin) %} disabled="disabled"{% endif %} />
                 <span class="switch-label" data-on="On" data-off="Off"  id="koschei_lbl"></span>
                 <span class="switch-handle"></span>

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -84,7 +84,7 @@ confusing what the difference is between that status an the per-branch status)
     </tr>
     <tr>
         <th>
-          <a target="_blank" href="https://apps.fedoraproject.org/koschei">
+          <a target="_blank" href="https://fedoraproject.org/wiki/Koschei">
             Koschei integration:
           </a>
         </th>


### PR DESCRIPTION
Any packager is allowed to change the koschei status of a package, this is true for the
API but wasn't in the UI. This is now fixed.

Fixes https://github.com/fedora-infra/pkgdb2/issues/215

The link under the ``koschei integration`` button to point to the wiki page instead of the
app directly (the wiki being clearer about what the app does).