### PR TITLE
Be less strict with bz package review summaries.

### DIFF
--- a/pkgdb2/api/extras.py
+++ b/pkgdb2/api/extras.py
@@ -721,13 +721,13 @@ def api_pkgrequest(bzid):
         jsonout.status_code = 500
         return jsonout
 
-    if not 'Review Request:' in bug.summary:
+    if bug.component != 'Package Review':
         httpcode = 400
         output['output'] = 'notok'
         output['error'] = 'Bugzilla ticket does not correspond '\
             'to a Review Request'
     else:
-        tmp = bug.summary.split('Review Request:')[1]
+        tmp = bug.summary.split(':', 1)[1]
         if not ' - ' in tmp:
             httpcode = 400
             output['output'] = 'notok'


### PR DESCRIPTION
mclasen reported today that he couldn't get pkgdb to auto-populate for
this ticket:  https://bugzilla.redhat.com/show_bug.cgi?id=1229395

That's because "Review Request:" != "Review request:".

This changes the pkgdb code to check the bug component instead, and
tries to be less strict when extracting the name and description.