### PR TITLE
Fixed broken link for project documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,4 +79,4 @@ Open your browser and visit http://localhost:5000 to check it out.
 
 
 For more information about the project configuration or deployment, check out
-the `documentation <http://packagedb.rtfd.org>`_
+the `documentation <http://pkgdb2.readthedocs.org>`_


### PR DESCRIPTION
The present [url](http://packagedb.readthedocs.org/en/latest/). Probably, what it should be is [this](http://pkgdb2.readthedocs.org/en/latest/)