### PR TITLE
Adjust how unique an admin action can be

### DIFF
--- a/alembic/versions/80939061434_update_unique_constraints_on_admin_.py
+++ b/alembic/versions/80939061434_update_unique_constraints_on_admin_.py
@@ -1,0 +1,43 @@
+"""Update unique constraints on admin_actions
+
+Revision ID: 80939061434
+Revises: 1f179f37f12b
+Create Date: 2015-10-05 11:16:07.256121
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '80939061434'
+down_revision = '1f179f37f12b'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    """ Drop status from the unique constraing of the admin_actions table.
+    """
+    op.drop_constraint(
+        "admin_actions_user_action_status_package_id_collection_id_key",
+        "admin_actions",
+        type_='unique',
+    )
+    op.create_unique_constraint(
+        "admin_actions_user_action_package_id_collection_id_key",
+        "admin_actions",
+        ['user', 'action', 'package_id', 'collection_id'],
+    )
+
+
+def downgrade():
+    """ Add status to the unique constraing of the admin_actions table. """
+    op.drop_constraint(
+        "admin_actions_user_action_package_id_collection_id_key",
+        "admin_actions",
+        type_='unique',
+    )
+    op.create_unique_constraint(
+        "admin_actions_user_action_status_package_id_collection_id_key",
+        "admin_actions",
+        ['user', 'action', 'status', 'package_id', 'collection_id'],
+    )

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -1712,15 +1712,15 @@ def add_new_branch_request(session, pkg_name, clt_to, user):
     if clt_to.name == 'Fedora EPEL':
         _validate_pkg(session, clt_to.version, package.name)
 
-    action = model.AdminAction.search(
+    actions = model.AdminAction.search(
         session,
         package_id=package.id,
         collection_id=clt_to.id,
         action='request.branch',
         user=user.username,
     )
-    if action:
-        action = action.pop()
+    if actions:
+        action = actions.pop()
         action._status = status
         action.message = None
     else:

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -1712,13 +1712,25 @@ def add_new_branch_request(session, pkg_name, clt_to, user):
     if clt_to.name == 'Fedora EPEL':
         _validate_pkg(session, clt_to.version, package.name)
 
-    action = model.AdminAction(
+    action = model.AdminAction.search(
+        session,
         package_id=package.id,
         collection_id=clt_to.id,
-        user=user.username,
-        _status=status,
         action='request.branch',
+        user=user.username,
     )
+    if action:
+        action = action.pop()
+        action._status = status
+        action.message = None
+    else:
+        action = model.AdminAction(
+            package_id=package.id,
+            collection_id=clt_to.id,
+            user=user.username,
+            _status=status,
+            action='request.branch',
+        )
 
     session.add(action)
 

--- a/pkgdb2/lib/model/__init__.py
+++ b/pkgdb2/lib/model/__init__.py
@@ -1838,7 +1838,8 @@ class AdminAction(BASE):
         return result
 
     @classmethod
-    def search(cls, session, package_id=None, packager=None, action=None,
+    def search(cls, session, package_id=None, collection_id=None,
+               packager=None, action=None, user=None,
                status=None, offset=None, limit=None, count=False):
         """ Return the list of actions present in the database and
         matching these criterias.
@@ -1863,11 +1864,17 @@ class AdminAction(BASE):
         if package_id:
             query = query.filter(cls.package_id == package_id)
 
+        if collection_id:
+            query = query.filter(cls.collection_id == collection_id)
+
         if packager:
             query = query.filter(cls.user == packager)
 
         if action:
             query = query.filter(cls.action == action)
+
+        if user:
+            query = query.filter(cls.user == user)
 
         if status:
             if status not in ['Awaiting Review', 'Pending']:

--- a/pkgdb2/lib/model/__init__.py
+++ b/pkgdb2/lib/model/__init__.py
@@ -1776,7 +1776,7 @@ class AdminAction(BASE):
 
     __table_args__ = (
         sa.UniqueConstraint(
-            'user', 'action', 'status', 'package_id', 'collection_id'),
+            'user', 'action', 'package_id', 'collection_id'),
     )
 
     package = relation(

--- a/pkgdb2/templates/list_actions.html
+++ b/pkgdb2/templates/list_actions.html
@@ -126,11 +126,14 @@
       <a href="{{ url_for('.admin_action_edit_status', action_id=action.id) }}">
         Update
       </a>
-    {% elif select and g.fas_user and g.fas_user.username == action.user and
-      action.status in ['Pending', 'Awaiting Review'] %}
+    {% elif select and g.fas_user and g.fas_user.username == action.user %}
       <a href="{{ url_for(
         '.package_request_edit', action_id=action.id) }}">
+          {% if action.status in ['Pending', 'Awaiting Review'] %}
           Update
+          {% else %}
+          Details
+          {% endif %}
       </a>
     {% endif %}
     </td>

--- a/pkgdb2/templates/list_actions.html
+++ b/pkgdb2/templates/list_actions.html
@@ -117,7 +117,10 @@
     </td>
     <td class="col_odd">{{ action.action }}</td>
     <td>{{ action.collection.branchname }}</td>
-    <td class="col_odd" >{{ action.status }}</td>
+    <td class="col_odd" >
+      {{ action.status }} {%- if action.message %}:
+      {{ action.message }}{% endif %}
+    </td>
     <td class="lastcel">
     {% if not select %}
       <a href="{{ url_for('.admin_action_edit_status', action_id=action.id) }}">

--- a/tests/test_flask_ui_admin.py
+++ b/tests/test_flask_ui_admin.py
@@ -217,7 +217,8 @@ class FlaskUiAdminTest(Modeltests):
                 1
             )
             self.assertTrue(
-                '<td class="col_odd" >Awaiting Review</td>' in output.data)
+                '<td class="col_odd" >\n      Awaiting Review\n    </td>'
+                in output.data)
 
             # One action Awaiting Review
             output = self.app.get('/admin/actions/?status=Awaiting Review')
@@ -230,7 +231,8 @@ class FlaskUiAdminTest(Modeltests):
                 1
             )
             self.assertTrue(
-                '<td class="col_odd" >Awaiting Review</td>' in output.data)
+                '<td class="col_odd" >\n      Awaiting Review\n    </td>'
+                in output.data)
 
             # Update
             output = self.app.get('/admin/action/1/status')


### PR DESCRIPTION
We cannot make unique an admin action based on its package, branch, user, action and status
otherwise we end up with a request closed, another open that cannot be closed with the same
status (unique constraints will fail).

What we can do otherwise is check if we have a request for that package on that branch and for this user and if so, we reset it.

This PR also adds a link to a request once it has been closed so that it can be sent to someone.