### PR TITLE
Fixed issue #204: Added tooltip for the buttons to explain what they do

### DIFF
--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -68,15 +68,15 @@ confusing what the difference is between that status an the per-branch status)
         <td colspan="2" align="center">
           <div id="monitoring_block">
             <input type="radio" id="no_monitoring" name="monitoring" value="0" />
-                <label for="no_monitoring" title="Click to toggle the monitor flag in the database" {%-
+                <label for="no_monitoring" title="Will toggle the monitor flag to monitor package for new releases" {%-
                     if package.monitoring_status == False %} class="active"{% endif
                     -%}>No monitoring</label> <br />
             <input type="radio" id="monitoring" name="monitoring" value="1" />
-                <label for="monitoring" title="Click to toggle the monitor flag in the database" {%-
+                <label for="monitoring" title="Will toggle the monitor flag to monitor bugs and the buildsystem for new builds" {%-
                     if package.monitoring_status == True %} class="active"{% endif
                     -%}>Bugs &amp; builds</label> <br />
             <input type="radio" id="no_build" name="monitoring" value="nobuild" />
-                <label for="no_build" title="Click to toggle the monitor flag in the database" {%-
+                <label for="no_build" title="Will toggle the monitor flag to monitor bugs for the package" {%-
                     if package.monitoring_status == "nobuild" %} class="active"{% endif
                     -%}>Bugs only</label>
             </div>

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -72,7 +72,7 @@ confusing what the difference is between that status an the per-branch status)
                     if package.monitoring_status == False %} class="active"{% endif
                     -%}>No monitoring</label> <br />
             <input type="radio" id="monitoring" name="monitoring" value="1" />
-                <label for="monitoring" title="Lists bugs and builds for the package" {%-
+                <label for="monitoring" title="Lists bugs and builds about the package" {%-
                     if package.monitoring_status == True %} class="active"{% endif
                     -%}>Bugs &amp; builds</label> <br />
             <input type="radio" id="no_build" name="monitoring" value="nobuild" />

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -68,7 +68,7 @@ confusing what the difference is between that status an the per-branch status)
         <td colspan="2" align="center">
           <div id="monitoring_block">
             <input type="radio" id="no_monitoring" name="monitoring" value="0" />
-                <label for="no_monitoring" {%-
+                <label for="no_monitoring" title="Click to toggle the monitor flag in the database" {%-
                     if package.monitoring_status == False %} class="active"{% endif
                     -%}>No monitoring</label> <br />
             <input type="radio" id="monitoring" name="monitoring" value="1" />
@@ -76,7 +76,7 @@ confusing what the difference is between that status an the per-branch status)
                     if package.monitoring_status == True %} class="active"{% endif
                     -%}>Bugs &amp; builds</label> <br />
             <input type="radio" id="no_build" name="monitoring" value="nobuild" />
-                <label for="no_build" {%-
+                <label for="no_build" title="Click to toggle the monitor flag in the database" {%-
                     if package.monitoring_status == "nobuild" %} class="active"{% endif
                     -%}>Bugs only</label>
             </div>

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -72,7 +72,7 @@ confusing what the difference is between that status an the per-branch status)
                     if package.monitoring_status == False %} class="active"{% endif
                     -%}>No monitoring</label> <br />
             <input type="radio" id="monitoring" name="monitoring" value="1" />
-                <label for="monitoring" {%-
+                <label for="monitoring" title="Lists bugs and builds for the package" {%-
                     if package.monitoring_status == True %} class="active"{% endif
                     -%}>Bugs &amp; builds</label> <br />
             <input type="radio" id="no_build" name="monitoring" value="nobuild" />

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -68,15 +68,15 @@ confusing what the difference is between that status an the per-branch status)
         <td colspan="2" align="center">
           <div id="monitoring_block">
             <input type="radio" id="no_monitoring" name="monitoring" value="0" />
-                <label for="no_monitoring" title="Will toggle the monitor flag to monitor package for new releases" {%-
+                <label for="no_monitoring" title="Turns off monitoring new releases for this package" {%-
                     if package.monitoring_status == False %} class="active"{% endif
                     -%}>No monitoring</label> <br />
             <input type="radio" id="monitoring" name="monitoring" value="1" />
-                <label for="monitoring" title="Will toggle the monitor flag to monitor bugs and the buildsystem for new builds" {%-
+                <label for="monitoring" title="Turns on monitoring and attempt to build new releases for this package" {%-
                     if package.monitoring_status == True %} class="active"{% endif
                     -%}>Bugs &amp; builds</label> <br />
             <input type="radio" id="no_build" name="monitoring" value="nobuild" />
-                <label for="no_build" title="Will toggle the monitor flag to monitor bugs for the package" {%-
+                <label for="no_build" title="Turns on monitoring of new releases but without attempt to build it" {%-
                     if package.monitoring_status == "nobuild" %} class="active"{% endif
                     -%}>Bugs only</label>
             </div>

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -72,7 +72,7 @@ confusing what the difference is between that status an the per-branch status)
                     if package.monitoring_status == False %} class="active"{% endif
                     -%}>No monitoring</label> <br />
             <input type="radio" id="monitoring" name="monitoring" value="1" />
-                <label for="monitoring" title="Lists bugs and builds about the package" {%-
+                <label for="monitoring" title="Click to toggle the monitor flag in the database" {%-
                     if package.monitoring_status == True %} class="active"{% endif
                     -%}>Bugs &amp; builds</label> <br />
             <input type="radio" id="no_build" name="monitoring" value="nobuild" />


### PR DESCRIPTION
Added tooltip for "Bugs and builds" button, in order to explain that they get bugs and builds about the package. @ralphbean @pypingou 