### PR TITLE
Fixed issue #246: Added tooltip for non-admins on clicking monitoring buttons

### DIFF
--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -68,15 +68,24 @@ confusing what the difference is between that status an the per-branch status)
         <td colspan="2" align="center">
           <div id="monitoring_block">
             <input type="radio" id="no_monitoring" name="monitoring" value="0" />
-                <label for="no_monitoring" {%-
+                <label for="no_monitoring" {%- if ('packager' in g.fas_user.groups or is_admin)
+                    %} title="Turns off monitoring new releases for this package"{%
+                    elif g.fas_user %} title="Only package admin or owner can turn off monitoring new releases"{%
+                    else %} title="Login to turn off monitoring new releases for this package"{% endif -%}{%-
                     if package.monitoring_status == False %} class="active"{% endif
                     -%}>No monitoring</label> <br />
             <input type="radio" id="monitoring" name="monitoring" value="1" />
-                <label for="monitoring" {%-
+                <label for="monitoring" {% if('packager' in g.fas_user.groups or is_admin)
+                    %} title="Turns on monitoring and attempt to build new releases for this package"{%
+                    elif g.fas_user %} title="Only package admin or owner can turn on monitoring and attempt to build new releases"{%
+                    else %} title="Login to turn on monitoring and attempt to build new releases"{% endif %}{%-
                     if package.monitoring_status == True %} class="active"{% endif
                     -%}>Bugs &amp; builds</label> <br />
             <input type="radio" id="no_build" name="monitoring" value="nobuild" />
-                <label for="no_build" {%-
+                <label for="no_build" {%- if ('packager' in g.fas_user.groups or is_admin)
+                        %} title="Turns on monitoring of new releases but without attempt to build it"{%
+                        elif g.fas_user %} title="Only package admin or owner can turn on monitoring new releases"{%
+                        else %} title="Login to turn on monitoring of new releases for the package without attempting to build it"{% endif -%}{%-
                     if package.monitoring_status == "nobuild" %} class="active"{% endif
                     -%}>Bugs only</label>
             </div>


### PR DESCRIPTION
@pypingou @ralphbean added an if-block to check if the user is a package admin or owner or just a random fas user, and accordingly the tooltips as well. Please let me know if this needs further changes :) thankyou.