### PR TITLE
Fixed issue #208: Implemented default cursor for monitoring buttons when user is logged out

### DIFF
--- a/pkgdb2/static/pkgdb.css
+++ b/pkgdb2/static/pkgdb.css
@@ -162,6 +162,9 @@ label.active, label.active:hover {
   background-position: 3px 50%!important;
 }
 
+label.inactive, label.inactive:hover {
+    cursor: default;
+}
 
 #actions {
   line-height: 1;

--- a/pkgdb2/static/pkgdb.css
+++ b/pkgdb2/static/pkgdb.css
@@ -162,7 +162,7 @@ label.active, label.active:hover {
   background-position: 3px 50%!important;
 }
 
-label.inactive, label.inactive:hover {
+label.mouse_inactive, label.mouse_inactive:hover {
     cursor: default;
 }
 

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -108,7 +108,6 @@ confusing what the difference is between that status an the per-branch status)
                 %} title="Only package admin or owner can turn on monitoring new releases"{%
                 else
                 %} title="Login to turn on monitoring of new releases for the package without attempting to build it"
-                class="mouse_inactive"
                 {%- endif -%}
                 {%- if package.monitoring_status == "nobuild" and g.fas_user %}
                     class="active"

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -80,7 +80,7 @@ confusing what the difference is between that status an the per-branch status)
                 {%- if package.monitoring_status == False and g.fas_user %}
                     class="active"
                 {%- elif package.monitoring_status == False %}
-                    class="active inactive"
+                    class="active mouse_inactive"
                 {%- endif -%}>
                 No monitoring
               </label> <br />
@@ -96,7 +96,7 @@ confusing what the difference is between that status an the per-branch status)
                 {%- if package.monitoring_status == True and g.fas_user %}
                     class="active"
                 {%- elif package.monitoring_status == True %}
-                    class="active inactive"
+                    class="active mouse_inactive"
                 {% endif-%}>
                 Bugs &amp; builds
               </label> <br />
@@ -108,12 +108,12 @@ confusing what the difference is between that status an the per-branch status)
                 %} title="Only package admin or owner can turn on monitoring new releases"{%
                 else
                 %} title="Login to turn on monitoring of new releases for the package without attempting to build it"
-                class="inactive"
+                class="mouse_inactive"
                 {%- endif -%}
                 {%- if package.monitoring_status == "nobuild" and g.fas_user %}
                     class="active"
                 {%- elif package.monitoring_status == "nobuild" %}
-                    class="active inactive"
+                    class="active mouse_inactive"
                 {%- endif -%}>
                 Bugs only
               </label>

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -71,21 +71,21 @@ confusing what the difference is between that status an the per-branch status)
                 <label for="no_monitoring" {%- if ('packager' in g.fas_user.groups or is_admin)
                     %} title="Turns off monitoring new releases for this package"{%
                     elif g.fas_user %} title="Only package admin or owner can turn off monitoring new releases"{%
-                    else %} title="Login to turn off monitoring new releases for this package"{% endif -%}{%-
+                    else %} title="Login to turn off monitoring new releases for this package" class="inactive" {% endif -%}{%-
                     if package.monitoring_status == False %} class="active"{% endif
                     -%}>No monitoring</label> <br />
             <input type="radio" id="monitoring" name="monitoring" value="1" />
                 <label for="monitoring" {% if('packager' in g.fas_user.groups or is_admin)
                     %} title="Turns on monitoring and attempt to build new releases for this package"{%
                     elif g.fas_user %} title="Only package admin or owner can turn on monitoring and attempt to build new releases"{%
-                    else %} title="Login to turn on monitoring and attempt to build new releases"{% endif %}{%-
+                    else %} title="Login to turn on monitoring and attempt to build new releases" class="inactive" {% endif %}{%-
                     if package.monitoring_status == True %} class="active"{% endif
                     -%}>Bugs &amp; builds</label> <br />
             <input type="radio" id="no_build" name="monitoring" value="nobuild" />
                 <label for="no_build" {%- if ('packager' in g.fas_user.groups or is_admin)
                         %} title="Turns on monitoring of new releases but without attempt to build it"{%
                         elif g.fas_user %} title="Only package admin or owner can turn on monitoring new releases"{%
-                        else %} title="Login to turn on monitoring of new releases for the package without attempting to build it"{% endif -%}{%-
+                        else %} title="Login to turn on monitoring of new releases for the package without attempting to build it" class="inactive" {% endif -%}{%-
                     if package.monitoring_status == "nobuild" %} class="active"{% endif
                     -%}>Bugs only</label>
             </div>

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -68,26 +68,55 @@ confusing what the difference is between that status an the per-branch status)
         <td colspan="2" align="center">
           <div id="monitoring_block">
             <input type="radio" id="no_monitoring" name="monitoring" value="0" />
-                <label for="no_monitoring" {%- if ('packager' in g.fas_user.groups or is_admin)
-                    %} title="Turns off monitoring new releases for this package"{%
-                    elif g.fas_user %} title="Only package admin or owner can turn off monitoring new releases"{%
-                    else %} title="Login to turn off monitoring new releases for this package" class="inactive" {% endif -%}{%-
-                    if package.monitoring_status == False %} class="active"{% endif
-                    -%}>No monitoring</label> <br />
+            {{ package.monitoring_status }}
+              <label for="no_monitoring" {%-
+                if ('packager' in g.fas_user.groups or is_admin)
+                %} title="Turns off monitoring new releases for this package"{%
+                elif g.fas_user
+                %} title="Only package admin or owner can turn off monitoring new releases"{%
+                else
+                %} title="Login to turn off monitoring new releases for this package"
+                {%- endif -%}
+                {%- if package.monitoring_status == False and g.fas_user %}
+                    class="active"
+                {%- elif package.monitoring_status == False %}
+                    class="active inactive"
+                {%- endif -%}>
+                No monitoring
+              </label> <br />
             <input type="radio" id="monitoring" name="monitoring" value="1" />
-                <label for="monitoring" {% if('packager' in g.fas_user.groups or is_admin)
-                    %} title="Turns on monitoring and attempt to build new releases for this package"{%
-                    elif g.fas_user %} title="Only package admin or owner can turn on monitoring and attempt to build new releases"{%
-                    else %} title="Login to turn on monitoring and attempt to build new releases" class="inactive" {% endif %}{%-
-                    if package.monitoring_status == True %} class="active"{% endif
-                    -%}>Bugs &amp; builds</label> <br />
+              <label for="monitoring" {%
+                if('packager' in g.fas_user.groups or is_admin)
+                %} title="Turns on monitoring and attempt to build new releases for this package"{%
+                elif g.fas_user
+                %} title="Only package admin or owner can turn on monitoring and attempt to build new releases"{%
+                else
+                %} title="Login to turn on monitoring and attempt to build new releases"
+                {%- endif %}
+                {%- if package.monitoring_status == True and g.fas_user %}
+                    class="active"
+                {%- elif package.monitoring_status == True %}
+                    class="active inactive"
+                {% endif-%}>
+                Bugs &amp; builds
+              </label> <br />
             <input type="radio" id="no_build" name="monitoring" value="nobuild" />
-                <label for="no_build" {%- if ('packager' in g.fas_user.groups or is_admin)
-                        %} title="Turns on monitoring of new releases but without attempt to build it"{%
-                        elif g.fas_user %} title="Only package admin or owner can turn on monitoring new releases"{%
-                        else %} title="Login to turn on monitoring of new releases for the package without attempting to build it" class="inactive" {% endif -%}{%-
-                    if package.monitoring_status == "nobuild" %} class="active"{% endif
-                    -%}>Bugs only</label>
+              <label for="no_build" {%-
+                if ('packager' in g.fas_user.groups or is_admin)
+                %} title="Turns on monitoring of new releases but without attempt to build it"{%
+                elif g.fas_user
+                %} title="Only package admin or owner can turn on monitoring new releases"{%
+                else
+                %} title="Login to turn on monitoring of new releases for the package without attempting to build it"
+                class="inactive"
+                {%- endif -%}
+                {%- if package.monitoring_status == "nobuild" and g.fas_user %}
+                    class="active"
+                {%- elif package.monitoring_status == "nobuild" %}
+                    class="active inactive"
+                {%- endif -%}>
+                Bugs only
+              </label>
             </div>
         </td>
     </tr>


### PR DESCRIPTION
@pypingou added an "inactive" class in pkgdb.css which enforces default cursor when the fas user is not logged in, while turns into a finger-pointer for a logged in fas user or package admin/owner. Let me know if this still needs work :) Thanks.