### PR TITLE
Add an allow_retire flag to collections

### DIFF
--- a/alembic/versions/563dd24698a7_add_the_allow_retire_field_to_the_.py
+++ b/alembic/versions/563dd24698a7_add_the_allow_retire_field_to_the_.py
@@ -30,7 +30,7 @@ def upgrade():
                '''SET allow_retire=TRUE WHERE name='Fedora EPEL';''')
     # Set FALSE to all EOL releases - correct behavior
     op.execute('''UPDATE "Collection" '''
-               '''SET allow_retire=TRUE WHERE status='EOL';''')
+               '''SET allow_retire=FALSE WHERE status='EOL';''')
     # Set True to all releases Under Development - mostly correct, except for
     # after final freeze
     op.execute('''UPDATE "Collection" '''

--- a/alembic/versions/563dd24698a7_add_the_allow_retire_field_to_the_.py
+++ b/alembic/versions/563dd24698a7_add_the_allow_retire_field_to_the_.py
@@ -1,0 +1,48 @@
+"""Add the allow_retire field to the collection table
+
+Revision ID: 563dd24698a7
+Revises: 80939061434
+Create Date: 2015-10-20 17:14:40.996865
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '563dd24698a7'
+down_revision = '80939061434'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    ''' Add the `allow_retire` column on the Collection table. '''
+    op.add_column(
+        'Collection',
+        sa.Column(
+            'allow_retire',
+            sa.Boolean,
+            default=False,
+            server_default='False',
+            nullable=True)
+    )
+    # Set True to EPEL - correct behavior
+    op.execute('''UPDATE "Collection" '''
+               '''SET allow_retire=TRUE WHERE name='Fedora EPEL';''')
+    # Set FALSE to all EOL releases - correct behavior
+    op.execute('''UPDATE "Collection" '''
+               '''SET allow_retire=TRUE WHERE status='EOL';''')
+    # Set True to all releases Under Development - mostly correct, except for
+    # after final freeze
+    op.execute('''UPDATE "Collection" '''
+               '''SET allow_retire=TRUE WHERE status='Under Development';''')
+
+    op.alter_column(
+        'Collection',
+        column_name='allow_retire',
+        nullable=False,
+        existing_nullable=True)
+
+
+def downgrade():
+    ''' Drop the `allow_retire` column of the Collection table. '''
+    op.drop_column('Collection', 'allow_retire')

--- a/alembic/versions/563dd24698a7_add_the_allow_retire_field_to_the_.py
+++ b/alembic/versions/563dd24698a7_add_the_allow_retire_field_to_the_.py
@@ -31,6 +31,9 @@ def upgrade():
     # Set FALSE to all EOL releases - correct behavior
     op.execute('''UPDATE "Collection" '''
                '''SET allow_retire=FALSE WHERE status='EOL';''')
+    # Set FALSE to all Active releases - correct behavior
+    op.execute('''UPDATE "Collection" '''
+               '''SET allow_retire=FALSE WHERE status='Active';''')
     # Set True to all releases Under Development - mostly correct, except for
     # after final freeze
     op.execute('''UPDATE "Collection" '''

--- a/pkgdb2/api/collections.py
+++ b/pkgdb2/api/collections.py
@@ -63,6 +63,9 @@ def api_collection_new():
     :arg branchname: The short name of the collection (ie: F-18).
     :arg dist_tag: The dist tag used by rpm for this collection (ie: .fc18).
     :arg kojiname: the name of the collection in koji.
+    :kwarg allow_retire: a boolean specifying if the collection should allow
+        retiring a package or not.
+        Defaults to ``False``.
 
     Sample response:
 
@@ -95,6 +98,7 @@ def api_collection_new():
         clt_branchname = form.branchname.data
         clt_disttag = form.dist_tag.data
         clt_koji_name = form.kojiname.data
+        clt_allow_retire = form.allow_retire.data or False
 
         try:
             message = pkgdblib.add_collection(
@@ -105,6 +109,7 @@ def api_collection_new():
                 clt_branchname=clt_branchname,
                 clt_disttag=clt_disttag,
                 clt_koji_name=clt_koji_name,
+                clt_allow_retire=clt_allow_retire,
                 user=flask.g.fas_user,
             )
             SESSION.commit()

--- a/pkgdb2/forms.py
+++ b/pkgdb2/forms.py
@@ -76,6 +76,10 @@ class AddCollectionForm(wtf.Form):
         'Dist tag',
         [wtforms.validators.Required()]
     )
+    allow_retire = wtforms.BooleanField(
+        'Allows retiring a package',
+        [wtforms.validators.optional()]
+    )
 
     def __init__(self, *args, **kwargs):
         """ Calls the default constructor with the normal argument but
@@ -95,6 +99,7 @@ class AddCollectionForm(wtf.Form):
             self.branchname.data = collection.branchname
             self.dist_tag.data = collection.dist_tag
             self.kojiname.data = collection.koji_name
+            self.allow_retire.data = collection.allow_retire
 
             # Set the drop down menu to the current value
             opt = (collection.status, collection.status)

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -1120,7 +1120,8 @@ def get_package_watch(
 
 
 def add_collection(session, clt_name, clt_version, clt_status,
-                   clt_branchname, clt_disttag, clt_koji_name, user):
+                   clt_branchname, clt_disttag, clt_koji_name,
+                   clt_allow_retire, user):
     """ Add a new collection to the database.
 
     This method only flushes the new object, nothing is committed to the
@@ -1132,7 +1133,9 @@ def add_collection(session, clt_name, clt_version, clt_status,
     :kwarg clt_status: the status of the collection.
     :kwarg clt_branchname: the branchname of the collection.
     :kwarg clt_disttag: the dist tag of the collection.
-    :kward clt_koji_name: the name of the collection in koji.
+    :kwarg clt_koji_name: the name of the collection in koji.
+    :kwarg clt_allow_retire: boolean specifying if the collection allows
+        retiring a package or not.
     :kwarg user: The user performing the update.
     :returns: a message informing that the collection was successfully
         created.
@@ -1157,6 +1160,7 @@ def add_collection(session, clt_name, clt_version, clt_status,
         branchname=clt_branchname,
         dist_tag=clt_disttag,
         koji_name=clt_koji_name,
+        allow_retire=clt_allow_retire,
     )
     try:
         session.add(collection)
@@ -1173,7 +1177,7 @@ def add_collection(session, clt_name, clt_version, clt_status,
 
 def edit_collection(session, collection, clt_name=None, clt_version=None,
                     clt_status=None, clt_branchname=None, clt_disttag=None,
-                    clt_koji_name=None, user=None):
+                    clt_koji_name=None, clt_allow_retire=None, user=None):
     """ Edit a specified collection
 
     This method only flushes the new object, nothing is committed to the
@@ -1186,7 +1190,9 @@ def edit_collection(session, collection, clt_name=None, clt_version=None,
     :kwarg clt_status: the new status of the collection.
     :kwarg clt_branchname: the new branchname of the collection.
     :kwarg clt_disttag: the new dist tag of the collection.
-    :kward clt_koji_name: the name of the collection in koji.
+    :kwarg clt_koji_name: the name of the collection in koji.
+    :kwarg clt_allow_retire: a boolean specifying if the collection allows
+        retiring a package.
     :kwarg user: The user performing the update.
     :returns: a message informing that the collection was successfully
         updated.
@@ -1223,6 +1229,9 @@ def edit_collection(session, collection, clt_name=None, clt_version=None,
     if clt_koji_name and clt_koji_name != collection.koji_name:
         collection.koji_name = clt_koji_name
         edited.append('koji_name')
+    if clt_allow_retire is not None and clt_allow_retire != collection.allow_retire:
+        collection.allow_retire = clt_allow_retire
+        edited.append('allow_retire')
 
     if edited:
         try:

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -618,11 +618,9 @@ def update_pkg_status(session, pkg_name, pkg_branch, status, user,
                 'You are not allowed to retire this package.')
 
         # Admins can deprecate everything
-        # Users can deprecate Fedora devel and EPEL branches
-        if pkgdb2.is_pkgdb_admin(user) \
-                or (collection.name == 'Fedora'
-                    and collection.status == 'Under Development') \
-                or collection.name == 'Fedora EPEL':
+        # Users can deprecate Fedora devel and EPEL branches, which
+        # are marked as allowing retiring a package.
+        if pkgdb2.is_pkgdb_admin(user) or collection.allow_retire:
 
             prev_poc = pkglisting.point_of_contact
             pkglisting.status = 'Retired'

--- a/pkgdb2/lib/model/__init__.py
+++ b/pkgdb2/lib/model/__init__.py
@@ -643,7 +643,8 @@ class Collection(BASE):
     )
 
     def __init__(self, name, version, status, owner,
-                 branchname=None, dist_tag=None, koji_name=None):
+                 branchname=None, dist_tag=None, koji_name=None,
+                 allow_retire=False):
         self.name = name
         self.version = version
         self.status = status
@@ -651,6 +652,7 @@ class Collection(BASE):
         self.branchname = branchname
         self.dist_tag = dist_tag
         self.koji_name = koji_name
+        self.allow_retire = allow_retire
 
     def __repr__(self):
         """ The string representation of this object.
@@ -670,6 +672,7 @@ class Collection(BASE):
             status=self.status,
             koji_name=self.koji_name,
             dist_tag=self.dist_tag,
+            allow_retire=self.allow_retire,
         )
 
     @classmethod

--- a/pkgdb2/lib/model/__init__.py
+++ b/pkgdb2/lib/model/__init__.py
@@ -633,6 +633,7 @@ class Collection(BASE):
     branchname = sa.Column(sa.String(32), unique=True, nullable=False)
     dist_tag = sa.Column(sa.String(32), unique=True, nullable=False)
     koji_name = sa.Column(sa.Text)
+    allow_retire = sa.Column(sa.Boolean, default=False, nullable=False)
 
     date_created = sa.Column(sa.DateTime, nullable=False,
                              default=datetime.datetime.utcnow)

--- a/pkgdb2/templates/collection.html
+++ b/pkgdb2/templates/collection.html
@@ -38,5 +38,9 @@
         <td>Dist-tag:</td>
         <td>{{ collection.dist_tag }}</td>
     </tr>
+    <tr>
+        <td>Allows package retirement</td>
+        <td>{{ collection.allow_retire }}</td>
+    </tr>
 </table>
 {% endblock %}

--- a/pkgdb2/templates/collection_edit.html
+++ b/pkgdb2/templates/collection_edit.html
@@ -18,6 +18,7 @@
     {{ render_field_in_row(form.branchname) }}
     {{ render_field_in_row(form.kojiname) }}
     {{ render_field_in_row(form.dist_tag) }}
+    {{ render_field_in_row(form.allow_retire) }}
   </table>
   <p class="buttons indent">
     <input type="submit" class="submit positive button" value="Edit">

--- a/pkgdb2/templates/collection_new.html
+++ b/pkgdb2/templates/collection_new.html
@@ -18,6 +18,7 @@
     {{ render_field_in_row(form.branchname) }}
     {{ render_field_in_row(form.kojiname) }}
     {{ render_field_in_row(form.dist_tag) }}
+    {{ render_field_in_row(form.allow_retire) }}
   </table>
   <p class="buttons indent">
     <input type="submit" class="submit positive button" value="Create">

--- a/pkgdb2/ui/collections.py
+++ b/pkgdb2/ui/collections.py
@@ -116,6 +116,7 @@ def collection_edit(collection):
         clt_branchname = form.branchname.data
         clt_disttag = form.dist_tag.data
         clt_koji_name = form.kojiname.data
+        clt_allow_retire = form.allow_retire.data
 
         try:
             pkgdblib.edit_collection(
@@ -127,6 +128,7 @@ def collection_edit(collection):
                 clt_branchname=clt_branchname,
                 clt_disttag=clt_disttag,
                 clt_koji_name=clt_koji_name,
+                clt_allow_retire=clt_allow_retire,
                 user=flask.g.fas_user,
             )
             SESSION.commit()
@@ -164,6 +166,7 @@ def collection_new():
         clt_branchname = form.branchname.data
         clt_disttag = form.dist_tag.data
         clt_koji_name = form.kojiname.data
+        clt_allow_retire = form.allow_retire.data
 
         try:
             message = pkgdblib.add_collection(
@@ -174,6 +177,7 @@ def collection_new():
                 clt_branchname=clt_branchname,
                 clt_disttag=clt_disttag,
                 clt_koji_name=clt_koji_name,
+                clt_allow_retire=clt_allow_retire,
                 user=flask.g.fas_user,
             )
             SESSION.commit()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -172,6 +172,7 @@ def create_collection(session):
         owner='kevin',
         branchname='master',
         dist_tag='devel',
+        allow_retire=True,
     )
     session.add(collection)
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -93,9 +93,9 @@ class Collectiontests(Modeltests):
         collection = model.Collection.by_name(self.session, 'f18')
         collection = collection.to_json()
         self.assertEqual(
-            set(collection.keys()), set(['branchname', 'version',
-                                         'name', 'status',
-                                         'dist_tag', 'koji_name']))
+            set(collection.keys()), set([
+                'allow_retire','branchname', 'version','name', 'status',
+                'dist_tag', 'koji_name']))
 
 
 if __name__ == '__main__':

--- a/tests/test_flask_api_collection.py
+++ b/tests/test_flask_api_collection.py
@@ -161,8 +161,9 @@ class FlaskApiCollectionTest(Modeltests):
                          ['collections', 'output'])
         self.assertEqual(len(output['collections']), 5)
         self.assertEqual(set(output['collections'][0].keys()),
-                         set(['branchname', 'version', 'name', 'status',
-                              'dist_tag', 'koji_name']))
+                         set([
+            'allow_retire', 'branchname', 'version', 'name', 'status',
+            'dist_tag', 'koji_name']))
 
         output = self.app.get('/api/collections/f*/')
         self.assertEqual(output.status_code, 200)
@@ -170,8 +171,9 @@ class FlaskApiCollectionTest(Modeltests):
         self.assertEqual(sorted(output.keys()),
                          ['collections', 'output'])
         self.assertEqual(set(output['collections'][0].keys()),
-                         set(['branchname', 'version', 'name', 'status',
-                              'dist_tag', 'koji_name']))
+                         set([
+            'allow_retire', 'branchname', 'version', 'name', 'status',
+            'dist_tag', 'koji_name']))
         self.assertEqual(len(output['collections']), 2)
         self.assertEqual(output['collections'][0]['name'], 'Fedora')
         self.assertEqual(output['collections'][0]['version'], '17')
@@ -222,7 +224,8 @@ class FlaskApiCollectionTest(Modeltests):
             'branchname': 'EL-6',
             'clt_status': 'ACTIVE',
             'dist_tag': '.el6',
-            'kojiname': 'epel6'
+            'kojiname': 'epel6',
+            'allow_retire': True,
         }
         with user_set(pkgdb2.APP, user):
             output = self.app.post('/api/collection/new/', data=data)
@@ -246,7 +249,8 @@ class FlaskApiCollectionTest(Modeltests):
             'branchname': 'EL-6',
             'clt_status': 'Active',
             'dist_tag': '.el6',
-            'kojiname': 'epel6'
+            'kojiname': 'epel6',
+            'allow_retire': True,
         }
         with user_set(pkgdb2.APP, user):
             output = self.app.post('/api/collection/new/', data=data)

--- a/tests/test_flask_api_packagers.py
+++ b/tests/test_flask_api_packagers.py
@@ -116,8 +116,8 @@ class FlaskApiPackagersTest(Modeltests):
                  u'acls', u'description', u'monitor', u'koschei_monitor']))
         self.assertEqual(
             set(output['acls'][0]['packagelist']['collection'].keys()),
-            set([u'branchname', u'version', u'name', u'status',
-                 u'dist_tag', u'koji_name']))
+            set(['allow_retire', 'branchname', 'version', 'name', 'status',
+                 'dist_tag', 'koji_name']))
         self.assertEqual(
             output['acls'][0]['packagelist']['package']['name'], 'guake')
         self.assertEqual(

--- a/tests/test_flask_api_packages.py
+++ b/tests/test_flask_api_packages.py
@@ -689,6 +689,7 @@ class FlaskApiPackagesTest(Modeltests):
             owner='kevin',
             branchname='epel7',
             dist_tag='.el7',
+            allow_retire=True,
         )
         self.session.add(collection)
         self.session.commit()
@@ -793,6 +794,7 @@ class FlaskApiPackagesTest(Modeltests):
             owner='kevin',
             branchname='epel7',
             dist_tag='.el7',
+            allow_retire=True,
         )
         self.session.add(collection)
         self.session.commit()
@@ -848,6 +850,7 @@ class FlaskApiPackagesTest(Modeltests):
             owner='kevin',
             branchname='epel7',
             dist_tag='.el7',
+            allow_retire=True,
         )
         self.session.add(collection)
         self.session.commit()

--- a/tests/test_package_listing_acl.py
+++ b/tests/test_package_listing_acl.py
@@ -78,6 +78,7 @@ class PackageListingAcltests(Modeltests):
                     'status': u'Active',
                     'koji_name': None,
                     'dist_tag': u'.fc18',
+                    'allow_retire': False,
                 },
                 'package': {
                     'upstream_url': u'http://guake.org',

--- a/tests/test_pkgdblib.py
+++ b/tests/test_pkgdblib.py
@@ -979,6 +979,7 @@ class PkgdbLibtests(Modeltests):
                           clt_branchname='f19',
                           clt_disttag='.fc19',
                           clt_koji_name='f19',
+                          clt_allow_retire=False,
                           user=FakeFasUser(),
                           )
         self.session.rollback()
@@ -990,6 +991,7 @@ class PkgdbLibtests(Modeltests):
                                 clt_branchname='f19',
                                 clt_disttag='.fc19',
                                 clt_koji_name='f19',
+                                clt_allow_retire=False,
                                 user=FakeFasUserAdmin(),
                                 )
         self.session.commit()


### PR DESCRIPTION
This flag can be used to toggle at any point in time whether someone is allowed to 
retire packages in it.

Fixes https://github.com/fedora-infra/pkgdb2/issues/257