### PR TITLE
Fix filtering user's requests using the side panel on the web-page

### DIFF
--- a/pkgdb2/ui/packagers.py
+++ b/pkgdb2/ui/packagers.py
@@ -133,8 +133,8 @@ def packager_info(packager):
 @UI.route('/packager/<packager>/requests')
 def packager_requests(packager):
     ''' Display the requests made by the specified packager. '''
-    action = flask.request.args.get('action', None)
-    package = flask.request.args.get('package', None)
+    action = flask.request.args.get('action') or None
+    package = flask.request.args.get('package') or None
     status = flask.request.args.get('status', 'All')
     limit = flask.request.args.get('limit', APP.config['ITEMS_PER_PAGE'])
     page = flask.request.args.get('page', 1)


### PR DESCRIPTION
Currently using the side panel, the url looks like:
  /packager/pingou/requests?package=&action=&status=Approved
So package and action are both ''.

With this change, they are evaluated and changed to None in those case
actually making filtering requests on the user's page working.