### PR TITLE
When un-retiring a package, request the review_url

### DIFF
--- a/pkgdb2/api/admin.py
+++ b/pkgdb2/api/admin.py
@@ -50,7 +50,7 @@ List admin actions
     :kwarg package: restrict the actions to a specific package.
     :kwarg packager: restrict the actions to a specific packager.
     :kwarg action: restrict the actions to a specific action, options are:
-        ``request.branch``, ``request.package``.
+        ``request.branch``, ``request.package`` and ``request.unretire``.
     :kwarg status: restrict the actions depending on their status, options
         are: ``Awaiting Review``, ``Approved``, ``Denied``, ``Obsolete``,
         ``Removed``.

--- a/pkgdb2/forms.py
+++ b/pkgdb2/forms.py
@@ -409,3 +409,11 @@ class EditActionStatusForm(wtf.Form):
                 (status, status)
                 for status in kwargs['status']
             ]
+
+
+class UnretireForm(BranchForm):
+    """ Form to ask for a package to be un-retired. """
+    review_url = wtforms.TextField(
+        'review_url',
+        [wtforms.validators.optional()],
+    )

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -1887,7 +1887,7 @@ def add_new_package_request(
     ))
 
 
-def add_unretire_request(session, pkg_name, pkg_branch, user):
+def add_unretire_request(session, pkg_name, pkg_branch, review_url, user):
     """ Register a new request to un-retire a package.
 
     This method only flushes the new objects.
@@ -1895,6 +1895,7 @@ def add_unretire_request(session, pkg_name, pkg_branch, user):
     :arg session: session with which to connect to the database.
     :arg pkg_name: the name of the package to unretire.
     :arg clt_to: the ``branchname`` of the collection to unretire.
+    :arg review_url: the url of the new review.
     :arg user: the user making the action.
     :raises pkgdb2.lib.PkgdbException: There are three conditions leading to
         this exception beeing raised:
@@ -1921,6 +1922,7 @@ def add_unretire_request(session, pkg_name, pkg_branch, user):
         user=user.username,
         _status='Awaiting Review',
         action='request.unretire',
+        info=json.dumps({'pkg_review_url': review_url}),
     )
 
     session.add(action)

--- a/pkgdb2/templates/actions_update.html
+++ b/pkgdb2/templates/actions_update.html
@@ -52,7 +52,8 @@
     </tr>
     <tr><td>Action:</td><td>{{ admin_action.action }}</td></tr>
     <tr><td>To branch:</td><td>{{ admin_action.collection.branchname }}</td></tr>
-    {% if admin_action.action == 'request.package' %}
+    {% if admin_action.action == 'request.package'
+        or admin_action.action == 'request.unretire' %}
     <tr>
       <td>Ticket</td>
       <td>

--- a/pkgdb2/templates/actions_update_ro.html
+++ b/pkgdb2/templates/actions_update_ro.html
@@ -27,7 +27,8 @@
   <tr><td>To branch:</td><td>{{ admin_action.collection.branchname }}</td></tr>
   <tr><td>Status</td><td>{{ admin_action.status }}</td></tr>
   <tr><td>Message</td><td>{{ admin_action.message }}</td></tr>
-  {% if admin_action.action == 'request.package' %}
+  {% if admin_action.action == 'request.package'
+      or admin_action.action == 'request.unretire' %}
   <tr>
       <td>Ticket</td>
       <td>

--- a/pkgdb2/templates/request_unretire.html
+++ b/pkgdb2/templates/request_unretire.html
@@ -1,0 +1,42 @@
+{% if full %}
+  {% extends "master.html" %}
+  {% block title %} Select branches | PkgDB {% endblock %}
+  {%block tag %}packages{% endblock %}
+{% endif %}
+
+{% from "_formhelpers.html" import render_field_in_row %}
+
+
+{% block content %}
+{% if not full %}
+<div title="{{ action.capitalize() }} package">
+{% endif %}
+
+<h1>
+  Select branches of package:
+  <a href="{{ url_for('.package_info', package=package.name) }}">
+    {{ package.name }}
+  </a>
+  to {{ action }}
+</h1>
+
+<form action="{{ url_for(
+    '.package_%s' % action, package=package.name, full=full) }}" method="post">
+  <table>
+    {{ render_field_in_row(form.branches) }}
+    {{ render_field_in_row(form.review_url, after="Required if you're un-retiring the master branch or an EPEL branch while keeping the master branch retired") }}
+  </table>
+  <p class="buttons indent">
+    <input type="submit" class="submit positive button" value="Select">
+    {% if full %}
+    <input type="button" value="Cancel" class="button" onclick="history.back();">
+    {% endif %}
+    {{ form.csrf_token }}
+  </p>
+  <p class="small">Use your mouse or the control key to select multiple
+    ACLs or branch at once</p>
+</form>
+{% if not full %}
+</div>
+{% endif %}
+{% endblock %}

--- a/pkgdb2/ui/packages.py
+++ b/pkgdb2/ui/packages.py
@@ -788,7 +788,7 @@ def package_unretire(package, full=True):
         and acl.status == 'Retired'
     ]
 
-    form = pkgdb2.forms.BranchForm(collections=collections)
+    form = pkgdb2.forms.UnretireForm(collections=collections)
 
     if form.validate_on_submit():
         for acl in package_acl:
@@ -799,6 +799,7 @@ def package_unretire(package, full=True):
                             session=SESSION,
                             pkg_name=package.name,
                             pkg_branch=acl.collection.branchname,
+                            review_url=form.review_url.data,
                             user=flask.g.fas_user,
                         )
                         flask.flash(
@@ -832,7 +833,7 @@ def package_unretire(package, full=True):
             flask.url_for('.package_info', package=package.name))
 
     return flask.render_template(
-        'branch_selection.html',
+        'request_unretire.html',
         full=full,
         package=package,
         form=form,

--- a/tests/test_pkgdblib.py
+++ b/tests/test_pkgdblib.py
@@ -2008,6 +2008,7 @@ class PkgdbLibtests(Modeltests):
             self.session,
             pkg_name='foo',
             pkg_branch='master',
+            review_url=None,
             user=FakeFasUser()
         )
 
@@ -2020,6 +2021,7 @@ class PkgdbLibtests(Modeltests):
             self.session,
             pkg_name='guake',
             pkg_branch='foo',
+            review_url=None,
             user=FakeFasUser()
         )
 
@@ -2027,6 +2029,7 @@ class PkgdbLibtests(Modeltests):
             self.session,
             pkg_name='guake',
             pkg_branch='master',
+            review_url=None,
             user=FakeFasUser()
         )
         self.assertEqual(


### PR DESCRIPTION
Fixes https://github.com/fedora-infra/pkgdb2/issues/277

But this enforce the review_url regardless of the retirement date.