### PR TITLE
Fix processing new package requests

### DIFF
--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -2537,29 +2537,30 @@ def edit_action_status(
         # that it was approved
         if action_status == 'Approved' \
                 and admin_action.action == 'request.package':
-            pkg = admin_action.info_data.get('package')
-            requests = search_actions(
-                session, package=pkg, action='request.package',
-                status='Awaiting Review')
-            requests.extend(search_actions(
-                session, package=pkg, action='request.branch',
-                status='Awaiting Review'))
-            for req in requests:
-                if req.collection.name.lower() != 'fedora':
-                    continue
-                for acl in ['commit', 'watchbugzilla',
-                            'watchcommits', 'approveacls']:
-                    set_acl_package(
-                        session,
-                        pkg_name=pkg,
-                        pkg_branch=req.collection.branchname,
-                        pkg_user=user.username,
-                        acl=acl,
-                        status='Approved',
-                        user=user,
-                        force=True,
-                    )
-                edit_action_status(session, req, 'Approved', user=user)
+            pkg = admin_action.info_data.get('pkg_name')
+            if pkg:
+                requests = search_actions(
+                    session, package=pkg, action='request.package',
+                    status='Awaiting Review')
+                requests.extend(search_actions(
+                    session, package=pkg, action='request.branch',
+                    status='Awaiting Review'))
+                for req in requests:
+                    if req.collection.name.lower() != 'fedora':
+                        continue
+                    for acl in ['commit', 'watchbugzilla',
+                                'watchcommits', 'approveacls']:
+                        set_acl_package(
+                            session,
+                            pkg_name=pkg,
+                            pkg_branch=req.collection.branchname,
+                            pkg_user=user.username,
+                            acl=acl,
+                            status='Approved',
+                            user=user,
+                            force=True,
+                        )
+                    edit_action_status(session, req, 'Approved', user=user)
 
     else:
         msg = 'Nothing to change.'


### PR DESCRIPTION
This commit does two fixes:
- It uses the proper key to retrieve the name of the package in the JSON
blob stored in the database to represent an admin action request
- If no package could be found with the provided package name, skip
without failing, this will allow pkgdb-admin to process the whole queue