### PR TITLE
Fix giving ACLs to someone

### DIFF
--- a/pkgdb2/ui/acls.py
+++ b/pkgdb2/ui/acls.py
@@ -262,6 +262,9 @@ def package_give_acls(namespace, package):
         namespaces=acls['namespaces'],
     )
     form.pkgname.data = package
+    if str(form.namespace.data) in ['None', '']:
+        form.namespace.data = 'rpms'
+
     if form.validate_on_submit():
         pkg_branchs = form.branches.data
         pkg_acls = form.acl.data

--- a/tests/test_flask_ui_acls.py
+++ b/tests/test_flask_ui_acls.py
@@ -999,6 +999,22 @@ class FlaskUiAclsTest(Modeltests):
             self.assertTrue('<li class="message">ACLs updated</li>' in
                             output.data)
 
+            # Add test for giving ACLs without providing the namespace in
+            # the form (in which case it relies on the one in the URL)
+            data = {
+                'branches': 'master',
+                'acl': 'watchcommits',
+                'user': 'kevin',
+                'acl_status': 'Approved',
+                'csrf_token': csrf_token,
+            }
+
+            output = self.app.post('/acl/rpms/guake/give/', data=data,
+                                   follow_redirects=True)
+            self.assertEqual(output.status_code, 200)
+            self.assertTrue('<li class="message">ACLs updated</li>' in
+                            output.data)
+
         user.username = 'Toshio'
         with user_set(pkgdb2.APP, user):
             output = self.app.get('/acl/rpms/foo/give/', follow_redirects=True)


### PR DESCRIPTION
To give ACLs to someone we need the namespace (to figure out which
package we're talking about), but this namespace might not actually be
passed on by the form, in this case, we'll just use the one provided in
the URL.

Adjust the unit-tests to cover this situation