### PR TITLE
Fix user-specific fedmenu in package timeline view

### DIFF
--- a/pkgdb2/templates/master.html
+++ b/pkgdb2/templates/master.html
@@ -169,7 +169,11 @@
             'user': '{{packager}}',
           {% endif %}
           {% if package is defined %}
+           {% if package.name is defined %}
             'package': '{{package.name}}',
+           {% else %}
+            'package': '{{package}}',
+           {% endif %}
             'alignment': 'horizontal',
           {% endif %}
       });

--- a/pkgdb2/templates/master.html
+++ b/pkgdb2/templates/master.html
@@ -165,7 +165,7 @@
           'url': '{{fedmenu_data_url}}',
           'mimeType': 'application/javascript',
           'position': 'bottom-right',
-          {% if packager is defined %}
+          {% if packager %}
             'user': '{{packager}}',
           {% endif %}
           {% if package is defined %}


### PR DESCRIPTION
When no user is specified for filtering, timeline view displays user-specific fedmenu with broken links.

Reproducer:
- go to https://admin.fedoraproject.org/pkgdb/package/ant/timeline

Actual result:
- user-specific fedmenu is displayed
- user-specific fedmenu contains broken links

Expected result:
- user-specific fedmenu is not displayed