### PR TITLE
Encode the package name on the link to koji as it otherwise doesn't work

### DIFF
--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -221,7 +221,8 @@ confusing what the difference is between that status an the per-branch status)
 
   <ul id="actions">
       <li>
-          <a href="http://koji.fedoraproject.org/koji/search?type=package&match=glob&terms={{ package.name }}"
+          <a href="http://koji.fedoraproject.org/koji/search?type=package&match=glob&terms={{
+      package.name | urlencode }}"
           class="koji">
           Builds status</a>
       </li>


### PR DESCRIPTION
Fixes https://fedorahosted.org/pkgdb2/ticket/51