### PR TITLE
Optimize the pkgdb2_branch script used when branching

### DIFF
--- a/pkgdb2/lib/notifications.py
+++ b/pkgdb2/lib/notifications.py
@@ -87,7 +87,8 @@ def email_publish(
         cc_email = [cc_email]
     if isinstance(to_email, basestring):
         to_email = [to_email]
-    to_email.extend(cc_email)
+    if cc_email:
+        to_email.extend(cc_email)
 
     # Send the message via our own SMTP server, but don't include the
     # envelope header.


### PR DESCRIPTION
Instead of iterating through the element in the DB and doing one query at a time,
we do two queries:
1/ creates the branch for all the packages
2/ sync the ACLs so that the new branch has the same has rawhide.

With this change, doing a branching 
* on my local machine from 1h45 to 25 minutes
* in stg from 5h+ to 32minutes