### PR TITLE
Properly handle bugzilla urls for unretirement requests

### DIFF
--- a/pkgdb2/api/acls.py
+++ b/pkgdb2/api/acls.py
@@ -34,7 +34,7 @@ import pkgdb2.forms as forms
 import pkgdb2.lib as pkgdblib
 from pkgdb2 import SESSION, APP
 from pkgdb2.api import API
-
+from pkgdb2.lib.exceptions import PkgdbBugzillaException, PkgdbException
 
 ## Some of the object we use here have inherited methods which apparently
 ## pylint does not detect.
@@ -143,7 +143,7 @@ def api_acl_update():
             SESSION.commit()
             output['output'] = 'ok'
             output['messages'] = messages
-        except pkgdblib.PkgdbException, err:
+        except PkgdbException as err:
             SESSION.rollback()
             output['output'] = 'notok'
             output['error'] = str(err)
@@ -234,11 +234,11 @@ def api_acl_reassign():
                 )
                 SESSION.commit()
                 messages.append(message)
-            except pkgdblib.PkgdbBugzillaException, err:  # pragma: no cover
+            except PkgdbBugzillaException as err:  # pragma: no cover
                 APP.logger.exception(err)
                 SESSION.rollback()
                 errors.add(str(err))
-            except pkgdblib.PkgdbException, err:
+            except PkgdbException as err:
                 SESSION.rollback()
                 errors.add(str(err))
 

--- a/pkgdb2/api/admin.py
+++ b/pkgdb2/api/admin.py
@@ -151,7 +151,7 @@ List admin actions
             status=status,
             count=True,
         )
-    except pkgdblib.PkgdbException, err:  # pragma: no cover
+    except pkgdblib.PkgdbException as err:  # pragma: no cover
         SESSION.rollback()
         output['output'] = 'notok'
         output['error'] = str(err)
@@ -336,7 +336,7 @@ Edit Admin Action status update
                 SESSION.commit()
                 output['output'] = 'ok'
                 output['messages'] = [message]
-            except pkgdblib.PkgdbException, err:  # pragma: no cover
+            except pkgdblib.PkgdbException as err:  # pragma: no cover
                 # We can only reach here in two cases:
                 # 1) the user is not an admin, but that's taken care of
                 #    by the decorator

--- a/pkgdb2/api/admin.py
+++ b/pkgdb2/api/admin.py
@@ -31,6 +31,7 @@ import pkgdb2.lib as pkgdblib
 import pkgdb2.forms
 from pkgdb2 import SESSION, is_admin
 from pkgdb2.api import API, get_limit
+from pkgdb2.lib.exceptions import PkgdbException
 
 
 @API.route('/admin/actions/')
@@ -151,7 +152,7 @@ List admin actions
             status=status,
             count=True,
         )
-    except pkgdblib.PkgdbException as err:  # pragma: no cover
+    except PkgdbException as err:  # pragma: no cover
         SESSION.rollback()
         output['output'] = 'notok'
         output['error'] = str(err)
@@ -336,7 +337,7 @@ Edit Admin Action status update
                 SESSION.commit()
                 output['output'] = 'ok'
                 output['messages'] = [message]
-            except pkgdblib.PkgdbException as err:  # pragma: no cover
+            except PkgdbException as err:  # pragma: no cover
                 # We can only reach here in two cases:
                 # 1) the user is not an admin, but that's taken care of
                 #    by the decorator

--- a/pkgdb2/api/collections.py
+++ b/pkgdb2/api/collections.py
@@ -117,7 +117,7 @@ def api_collection_new():
             output['messages'] = [message]
         # Apparently we're pretty tight on checks and looks like we cannot
         # raise this exception in a normal situation
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             output['output'] = 'notok'
             output['error'] = str(err)
@@ -195,7 +195,7 @@ def api_collection_status(collection):
                 SESSION.commit()
                 output['output'] = 'ok'
                 output['messages'] = [message]
-            except pkgdblib.PkgdbException, err:
+            except pkgdblib.PkgdbException as err:
                 SESSION.rollback()
                 output['output'] = 'notok'
                 output['error'] = str(err)

--- a/pkgdb2/api/collections.py
+++ b/pkgdb2/api/collections.py
@@ -32,6 +32,7 @@ import pkgdb2.lib as pkgdblib
 from pkgdb2 import SESSION, forms, is_admin
 from pkgdb2.api import API
 from pkgdb2.lib import model
+from pkgdb2.lib.exceptions import PkgdbException
 
 
 ## Some of the object we use here have inherited methods which apparently
@@ -117,7 +118,7 @@ def api_collection_new():
             output['messages'] = [message]
         # Apparently we're pretty tight on checks and looks like we cannot
         # raise this exception in a normal situation
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             output['output'] = 'notok'
             output['error'] = str(err)
@@ -195,7 +196,7 @@ def api_collection_status(collection):
                 SESSION.commit()
                 output['output'] = 'ok'
                 output['messages'] = [message]
-            except pkgdblib.PkgdbException as err:
+            except PkgdbException as err:
                 SESSION.rollback()
                 output['output'] = 'notok'
                 output['error'] = str(err)

--- a/pkgdb2/api/packages.py
+++ b/pkgdb2/api/packages.py
@@ -1616,7 +1616,7 @@ def api_branch_request(package, namespace='rpms'):
                 output['output'] = 'notok'
                 output['error'] = str(err)
                 httpcode = 400
-            except SQLAlchemyError, err:  # pragma: no cover
+            except SQLAlchemyError as err:  # pragma: no cover
                 SESSION.rollback()
                 APP.logger.exception(err)
                 output['output'] = 'notok'

--- a/pkgdb2/api/packages.py
+++ b/pkgdb2/api/packages.py
@@ -36,6 +36,7 @@ from sqlalchemy.orm.exc import NoResultFound
 import pkgdb2.lib as pkgdblib
 from pkgdb2 import APP, SESSION, forms, is_admin, packager_login_required
 from pkgdb2.api import API, get_limit
+from pkgdb2.lib.exceptions import PkgdbException, PkgdbBugzillaException
 
 
 ## Some of the object we use here have inherited methods which apparently
@@ -152,7 +153,7 @@ def api_package_new():
             SESSION.commit()
             output['output'] = 'ok'
             output['messages'] = [message]
-        except pkgdblib.PkgdbException, err:
+        except PkgdbException as err:
             SESSION.rollback()
             output['output'] = 'notok'
             output['error'] = str(err)
@@ -270,7 +271,7 @@ def api_package_edit():
                 SESSION.commit()
                 output['output'] = 'ok'
                 output['messages'] = [message]
-            except pkgdblib.PkgdbException, err:  # pragma: no cover
+            except PkgdbException as err:  # pragma: no cover
                 # We can only reach here in two cases:
                 # 1) the user is not an admin, but that's taken care of
                 #    by the decorator
@@ -361,7 +362,7 @@ def api_package_orphan():
 
                 messages.append(message)
                 SESSION.commit()
-            except pkgdblib.PkgdbException, err:
+            except PkgdbException as err:
                 SESSION.rollback()
                 errors.add(str(err))
 
@@ -461,11 +462,11 @@ def api_package_unorphan():
                 )
                 messages.append(message)
                 SESSION.commit()
-            except pkgdblib.PkgdbBugzillaException, err:  # pragma: no cover
+            except PkgdbBugzillaException as err:  # pragma: no cover
                 APP.logger.exception(err)
                 SESSION.rollback()
                 errors.add(str(err))
-            except pkgdblib.PkgdbException, err:
+            except PkgdbException as err:
                 SESSION.rollback()
                 errors.add(str(err))
 
@@ -563,7 +564,7 @@ def api_package_retire():
                 )
                 messages.append(message)
             SESSION.commit()
-        except pkgdblib.PkgdbException, err:
+        except PkgdbException as err:
             SESSION.rollback()
             errors.add(str(err))
 
@@ -663,7 +664,7 @@ def api_package_unretire():
             SESSION.commit()
             output['output'] = 'ok'
             output['messages'] = messages
-        except pkgdblib.PkgdbException, err:
+        except PkgdbException as err:
             SESSION.rollback()
             output['output'] = 'notok'
             output['error'] = str(err)
@@ -1109,7 +1110,7 @@ def api_package_list(namespace=None, pattern=None):
                 output['page'] = int(page)
                 output['page_total'] = int(ceil(packages_count / float(limit)))
 
-    except pkgdblib.PkgdbException, err:
+    except PkgdbException as err:
         SESSION.rollback()
         output['output'] = 'notok'
         output['error'] = str(err)
@@ -1198,7 +1199,7 @@ def api_package_critpath():
                 output['output'] = 'notok'
                 output['error'] = 'Nothing to update'
                 httpcode = 500
-        except pkgdblib.PkgdbException, err:
+        except PkgdbException as err:
             SESSION.rollback()
             output['output'] = 'notok'
             output['error'] = str(err)
@@ -1277,7 +1278,7 @@ def api_monitor_package(package, status, namespace='rpms'):
         SESSION.commit()
         output['output'] = 'ok'
         output['messages'] = msg
-    except pkgdblib.PkgdbException, err:
+    except PkgdbException as err:
         SESSION.rollback()
         output['output'] = 'notok'
         output['error'] = str(err)
@@ -1340,7 +1341,7 @@ def api_koschei_package(package, status, namespace='rpms'):
         SESSION.commit()
         output['output'] = 'ok'
         output['messages'] = msg
-    except pkgdblib.PkgdbException, err:
+    except PkgdbException as err:
         SESSION.rollback()
         output['output'] = 'notok'
         output['error'] = str(err)
@@ -1489,7 +1490,7 @@ def api_package_request():
             SESSION.commit()
             output['output'] = 'ok'
             output['messages'] = messages
-        except pkgdblib.PkgdbException, err:
+        except PkgdbException as err:
             SESSION.rollback()
             output['output'] = 'notok'
             output['error'] = str(err)
@@ -1610,7 +1611,7 @@ def api_branch_request(package, namespace='rpms'):
                 SESSION.commit()
                 output['output'] = 'ok'
                 output['messages'] = messages
-            except pkgdblib.PkgdbException, err:  # pragma: no cover
+            except PkgdbException as err:  # pragma: no cover
                 SESSION.rollback()
                 output['output'] = 'notok'
                 output['error'] = str(err)

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -1975,11 +1975,22 @@ def add_new_package_request(
     if pkg_collection.startswith(('el', 'epel')):
         _validate_pkg(session, pkg_collection[-1:], pkg_name)
 
+    # pkg_description, pkg_upstream_url and pkg_review_url should be None if
+    # empty
     if pkg_description:
         pkg_description = pkg_description.strip()
+    if not pkg_description:
+        pkg_description = None
 
     if pkg_upstream_url:
         pkg_upstream_url = pkg_upstream_url.strip()
+    if not pkg_upstream_url:
+        pkg_upstream_url = None
+
+    if pkg_review_url:
+        pkg_review_url = pkg_review_url.strip()
+    if not pkg_review_url:
+        pkg_review_url = None
 
     info = {
         'pkg_name': pkg_name.strip(),
@@ -1988,7 +1999,7 @@ def add_new_package_request(
         'pkg_status': pkg_status.strip(),
         'pkg_collection': pkg_collection.strip(),
         'pkg_poc': pkg_poc.strip(),
-        'pkg_review_url': pkg_review_url.strip() if pkg_review_url else None,
+        'pkg_review_url': pkg_review_url,
         'pkg_upstream_url': pkg_upstream_url,
         'pkg_critpath': pkg_critpath,
         'pkg_namespace': pkg_namespace,

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -244,7 +244,7 @@ def add_package(
     session.add(package)
     try:
         session.flush()
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         pkgdb2.LOG.exception(err)
         session.rollback()
         raise PkgdbException('Could not create package')
@@ -258,7 +258,7 @@ def add_package(
         session.add(pkglisting)
         try:
             session.flush()
-        except SQLAlchemyError, err:  # pragma: no cover
+        except SQLAlchemyError as err:  # pragma: no cover
             pkgdb2.LOG.exception(err)
             session.rollback()
             raise PkgdbException('Could not add packages to collections')
@@ -288,7 +288,7 @@ def add_package(
     try:
         session.flush()
         return 'Package created'
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         pkgdb2.LOG.exception(err)
         raise PkgdbException('Could not add ACLs')
 
@@ -1203,7 +1203,7 @@ def add_collection(session, clt_name, clt_version, clt_status,
             collection=collection.to_json(),
         ))
         return 'Collection "%s" created' % collection.branchname
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         pkgdb2.LOG.exception(err)
         raise PkgdbException('Could not add Collection to the database.')
 
@@ -1282,7 +1282,7 @@ def edit_collection(session, collection, clt_name=None, clt_version=None,
                 )
             )
             return 'Collection "%s" edited' % collection.branchname
-        except SQLAlchemyError, err:  # pragma: no cover
+        except SQLAlchemyError as err:  # pragma: no cover
             pkgdb2.LOG.exception(err)
             raise PkgdbException('Could not edit Collection.')
 
@@ -1351,7 +1351,7 @@ def edit_package(
                 package=package.to_json(acls=False),
             ))
             return 'Package "%s" edited' % package.name
-        except SQLAlchemyError, err:  # pragma: no cover
+        except SQLAlchemyError as err:  # pragma: no cover
             pkgdb2.LOG.exception(err)
             raise PkgdbException('Could not edit package.')
 
@@ -1403,7 +1403,7 @@ def update_collection_status(session, clt_branchname, clt_status, user):
     except NoResultFound:  # pragma: no cover
         raise PkgdbException('Could not find collection "%s"' %
                              clt_branchname)
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         pkgdb2.LOG.exception(err)
         raise PkgdbException('Could not update the status of collection'
                              '"%s".' % clt_branchname)
@@ -1779,7 +1779,7 @@ def add_branch(session, clt_from, clt_to, user):
         messages.append(
             'SUCCESS: successfully branched (PackageListing) %s from '
             'to %s %s' % (clt_from.name, clt_to.name, clt_to.version))
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         session.rollback()
         pkgdb2.LOG.debug(err)
         messages.append(
@@ -1792,7 +1792,7 @@ def add_branch(session, clt_from, clt_to, user):
         messages.append(
             'SUCCESS: successfully branched (PackageListingAcl) %s from '
             'to %s %s' % (clt_from.name, clt_to.name, clt_to.version))
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         session.rollback()
         pkgdb2.LOG.debug(err)
         messages.append(
@@ -2452,7 +2452,7 @@ def set_critpath_packages(
             branches=branches,
             package=package.to_json(),
         ))
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         pkgdb2.LOG.exception(err)
         raise PkgdbException('Could not edit package.')
 
@@ -2535,7 +2535,7 @@ def set_monitor_package(session, namespace, pkg_name, status, user):
                     package=package.to_json(acls=False),
                 )
             )
-        except SQLAlchemyError, err:  # pragma: no cover
+        except SQLAlchemyError as err:  # pragma: no cover
             pkgdb2.LOG.exception(err)
             raise PkgdbException('Could not update monitoring status.')
 
@@ -2593,7 +2593,7 @@ def set_koschei_monitor_package(session, namespace, pkg_name, status, user):
                     package=package.to_json(acls=False),
                 )
             )
-        except SQLAlchemyError, err:  # pragma: no cover
+        except SQLAlchemyError as err:  # pragma: no cover
             pkgdb2.LOG.exception(err)
             raise PkgdbException(
                 'Could not update Koschei monitoring status.')
@@ -2688,7 +2688,7 @@ def edit_action_status(
                     new_status=action_status,
                     action=admin_action.to_json(),
                 ))
-        except SQLAlchemyError, err:
+        except SQLAlchemyError as err:
             session.rollback()
             pkgdb2.LOG.exception(err)
             raise PkgdbException('Could not edit action.')
@@ -2775,7 +2775,7 @@ def add_namespace(session, namespace, user):
             namespace=namespace,
         ))
         return 'Namespace "%s" created' % namespace
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         pkgdb2.LOG.exception(err)
         session.rollback()
         raise PkgdbException(
@@ -2820,7 +2820,7 @@ def drop_namespace(session, namespace, user):
             namespace=namespace,
         ))
         return 'Namespace "%s" removed' % namespace
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         pkgdb2.LOG.exception(err)
         session.rollback()
         raise PkgdbException(

--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -58,6 +58,7 @@ ACLS = ['commit', 'watchbugzilla', 'watchcommits', 'approveacls']
 ## Ignore variable name that are too short
 # pylint: disable=C0103
 
+
 def _validate_poc(pkg_poc):
     """ Validate is the provided ``pkg_poc`` is a valid poc for a package.
 
@@ -956,7 +957,7 @@ def search_actions(
     )
 
 
-def search_logs(session,namespace=None, package=None, packager=None,
+def search_logs(session, namespace=None, package=None, packager=None,
                 from_date=None, page=None, limit=None, count=False):
     """ Return the list of Collection matching the given criteria.
 
@@ -1261,7 +1262,8 @@ def edit_collection(session, collection, clt_name=None, clt_version=None,
     if clt_koji_name and clt_koji_name != collection.koji_name:
         collection.koji_name = clt_koji_name
         edited.append('koji_name')
-    if clt_allow_retire is not None and clt_allow_retire != collection.allow_retire:
+    if clt_allow_retire is not None and \
+            clt_allow_retire != collection.allow_retire:
         collection.allow_retire = clt_allow_retire
         edited.append('allow_retire')
 
@@ -1435,7 +1437,7 @@ def get_pending_acl_user(session, user=None):
                 'collection': package.packagelist.collection.branchname,
                 'acl': package.acl,
                 'status': package.status,
-             }
+            }
         )
     return output
 
@@ -1754,7 +1756,8 @@ def add_branch(session, clt_from, clt_to, user):
     )
     SELECT "PackageListingAcl".fas_name, p2.id,
            "PackageListingAcl".acl, "PackageListingAcl".status, '%s'
-    FROM "PackageListing" as p1, "PackageListing" as p2, "PackageListingAcl", "Package"
+    FROM "PackageListing" as p1, "PackageListing" as p2, "PackageListingAcl",
+         "Package"
     WHERE p1.collection_id = %s
     AND p2.collection_id = %s
     AND p1.package_id = p2.package_id
@@ -1787,7 +1790,7 @@ def add_branch(session, clt_from, clt_to, user):
         session.execute(q2)
         session.commit()
         messages.append(
-                'SUCCESS: successfully branched (PackageListingAcl) %s from '
+            'SUCCESS: successfully branched (PackageListingAcl) %s from '
             'to %s %s' % (clt_from.name, clt_to.name, clt_to.version))
     except SQLAlchemyError, err:  # pragma: no cover
         session.rollback()
@@ -1972,15 +1975,21 @@ def add_new_package_request(
     if pkg_collection.startswith(('el', 'epel')):
         _validate_pkg(session, pkg_collection[-1:], pkg_name)
 
+    if pkg_description:
+        pkg_description = pkg_description.strip()
+
+    if pkg_upstream_url:
+        pkg_upstream_url = pkg_upstream_url.strip()
+
     info = {
         'pkg_name': pkg_name.strip(),
         'pkg_summary': pkg_summary.strip(),
-        'pkg_description': pkg_description.strip() if pkg_description else None,
+        'pkg_description': pkg_description,
         'pkg_status': pkg_status.strip(),
         'pkg_collection': pkg_collection.strip(),
         'pkg_poc': pkg_poc.strip(),
         'pkg_review_url': pkg_review_url.strip() if pkg_review_url else None,
-        'pkg_upstream_url': pkg_upstream_url.strip() if pkg_upstream_url else None,
+        'pkg_upstream_url': pkg_upstream_url,
         'pkg_critpath': pkg_critpath,
         'pkg_namespace': pkg_namespace,
         'monitoring_status': monitoring_status,
@@ -2252,11 +2261,11 @@ def _vcs_acls_json(packages, skip_pp=None):
             }
 
         if group:
-            output[namespace][pkgname][branchname
-                ]['commit']['groups'].append(group)
+            output[namespace][pkgname][branchname]['commit']['groups'].append(
+                group)
         if user:
-            output[namespace][pkgname][branchname
-                ]['commit']['people'].append(user)
+            output[namespace][pkgname][branchname]['commit']['people'].append(
+                user)
     return output
 
 
@@ -2313,7 +2322,6 @@ def _vcs_acls_text(packages, skip_pp=None):
             else:
                 if group and groups:  # pragma: no cover
                     group = ',' + group
-
 
                 output[pkgname][branchname] = {
                     'name': pkgname,

--- a/pkgdb2/lib/notifications.py
+++ b/pkgdb2/lib/notifications.py
@@ -45,7 +45,7 @@ def fedmsg_publish(*args, **kwargs):  # pragma: no cover
     try:
         import fedmsg
         fedmsg.publish(*args, **kwargs)
-    except Exception, err:
+    except Exception as err:
         warnings.warn(str(err))
 
 

--- a/pkgdb2/lib/utils.py
+++ b/pkgdb2/lib/utils.py
@@ -194,7 +194,7 @@ def set_bugzilla_owner(
                     'PKGDB2_BUGZILLA_NOTIFICATION']:  # pragma: no cover
                 try:
                     bug.setassignee(assigned_to=bz_mail, comment=bz_comment)
-                except Exception, err:
+                except Exception as err:
                     raise pkgdb2.lib.exceptions.PkgdbBugzillaException(
                         'An error occured while calling bugzilla: %s'
                         % str(err)

--- a/pkgdb2/ui/acls.py
+++ b/pkgdb2/ui/acls.py
@@ -99,7 +99,7 @@ def request_acl(namespace, package):
                 package=package.name)
             )
 
-        except pkgdblib.PkgdbException, err:
+        except pkgdblib.PkgdbException as err:
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -161,7 +161,7 @@ def request_acl_all_branch(namespace, package, acl):
                 flask.flash(
                     'ACL %s requested on branch %s' % (acl, branch))
                 SESSION.commit()
-            except pkgdblib.PkgdbException, err:
+            except pkgdblib.PkgdbException as err:
                 SESSION.rollback()
                 flask.flash(str(err), 'error')
 
@@ -220,14 +220,14 @@ def giveup_acl(namespace, package, acl):
                 flask.flash(
                     'Your ACL %s is obsoleted on branch %s of package %s'
                     % (acl, branch, package))
-            except pkgdblib.PkgdbException, err:  # pragma: no cover
+            except pkgdblib.PkgdbException as err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
 
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -290,7 +290,7 @@ def package_give_acls(namespace, package):
             flask.flash('ACLs updated')
             return flask.redirect(flask.url_for(
                 '.package_info', namespace=namespace, package=package))
-        except pkgdblib.PkgdbException, err:
+        except pkgdblib.PkgdbException as err:
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -341,7 +341,7 @@ def watch_package(namespace, package):
             SESSION.commit()
             flask.flash('ACLs updated')
         # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
     return flask.redirect(flask.url_for(
@@ -385,7 +385,7 @@ def unwatch_package(namespace, package):
             SESSION.commit()
             flask.flash('ACLs updated')
         # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
     return flask.redirect(flask.url_for(
@@ -468,7 +468,7 @@ def comaintain_package(namespace, package):
             else:
                 flask.flash('Nothing to update')
         # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
     return flask.redirect(flask.url_for(
@@ -517,7 +517,7 @@ def dropcommit_package(namespace, package):
             SESSION.commit()
             flask.flash('ACLs updated')
         # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
     return flask.redirect(flask.url_for(
@@ -563,7 +563,7 @@ def pending_acl_approve():
             SESSION.commit()
             flask.flash('All ACLs approved')
             # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -595,7 +595,7 @@ def pending_acl_deny():
             SESSION.commit()
             flask.flash('All ACLs denied')
             # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 

--- a/pkgdb2/ui/acls.py
+++ b/pkgdb2/ui/acls.py
@@ -32,6 +32,7 @@ import pkgdb2.lib as pkgdblib
 from pkgdb2 import (SESSION, APP, fas_login_required,
                     packager_login_required)
 from pkgdb2.ui import UI
+from pkgdb2.lib.exceptions import PkgdbException
 
 
 ## Some of the object we use here have inherited methods which apparently
@@ -99,7 +100,7 @@ def request_acl(namespace, package):
                 package=package.name)
             )
 
-        except pkgdblib.PkgdbException as err:
+        except PkgdbException as err:
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -161,7 +162,7 @@ def request_acl_all_branch(namespace, package, acl):
                 flask.flash(
                     'ACL %s requested on branch %s' % (acl, branch))
                 SESSION.commit()
-            except pkgdblib.PkgdbException as err:
+            except PkgdbException as err:
                 SESSION.rollback()
                 flask.flash(str(err), 'error')
 
@@ -220,14 +221,14 @@ def giveup_acl(namespace, package, acl):
                 flask.flash(
                     'Your ACL %s is obsoleted on branch %s of package %s'
                     % (acl, branch, package))
-            except pkgdblib.PkgdbException as err:  # pragma: no cover
+            except PkgdbException as err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
 
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -290,7 +291,7 @@ def package_give_acls(namespace, package):
             flask.flash('ACLs updated')
             return flask.redirect(flask.url_for(
                 '.package_info', namespace=namespace, package=package))
-        except pkgdblib.PkgdbException as err:
+        except PkgdbException as err:
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -341,7 +342,7 @@ def watch_package(namespace, package):
             SESSION.commit()
             flask.flash('ACLs updated')
         # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
     return flask.redirect(flask.url_for(
@@ -385,7 +386,7 @@ def unwatch_package(namespace, package):
             SESSION.commit()
             flask.flash('ACLs updated')
         # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
     return flask.redirect(flask.url_for(
@@ -468,7 +469,7 @@ def comaintain_package(namespace, package):
             else:
                 flask.flash('Nothing to update')
         # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
     return flask.redirect(flask.url_for(
@@ -517,7 +518,7 @@ def dropcommit_package(namespace, package):
             SESSION.commit()
             flask.flash('ACLs updated')
         # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
     return flask.redirect(flask.url_for(
@@ -563,7 +564,7 @@ def pending_acl_approve():
             SESSION.commit()
             flask.flash('All ACLs approved')
             # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -595,7 +596,7 @@ def pending_acl_deny():
             SESSION.commit()
             flask.flash('All ACLs denied')
             # Let's keep this in although we should never see it
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 

--- a/pkgdb2/ui/admin.py
+++ b/pkgdb2/ui/admin.py
@@ -97,7 +97,7 @@ def admin_log():
             from_date=from_date,
             count=True
         )
-    except pkgdblib.PkgdbException, err:
+    except pkgdblib.PkgdbException as err:
         flask.flash(err, 'errors')
 
     total_page = int(ceil(cnt_logs / float(limit)))
@@ -160,7 +160,7 @@ def admin_actions():
             status=status,
             count=True
         )
-    except pkgdblib.PkgdbException, err:
+    except pkgdblib.PkgdbException as err:
         flask.flash(err, 'errors')
 
     total_page = int(ceil(cnt_actions / float(limit)))
@@ -215,7 +215,7 @@ def admin_action_edit_status(action_id):
             )
             SESSION.commit()
             flask.flash(message)
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             # We can only reach here in two cases:
             # 1) the user is not an admin, but that's taken care of
             #    by the decorator
@@ -270,7 +270,7 @@ def admin_drop_namespace():
             )
             SESSION.commit()
             flask.flash(message)
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             # We can only reach here in two cases:
             # 1) the user is not an admin, but that's taken care of
             #    by the decorator
@@ -301,7 +301,7 @@ def admin_add_namespace():
             )
             SESSION.commit()
             flask.flash(message)
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             # We can only reach here in two cases:
             # 1) the user is not an admin, but that's taken care of
             #    by the decorator

--- a/pkgdb2/ui/admin.py
+++ b/pkgdb2/ui/admin.py
@@ -32,6 +32,7 @@ import pkgdb2.forms
 import pkgdb2.lib as pkgdblib
 from pkgdb2 import SESSION, APP, is_admin
 from pkgdb2.ui import UI
+from pkgdb2.lib.exceptions import PkgdbException
 
 
 @UI.route('/admin/')
@@ -97,7 +98,7 @@ def admin_log():
             from_date=from_date,
             count=True
         )
-    except pkgdblib.PkgdbException as err:
+    except PkgdbException as err:
         flask.flash(err, 'errors')
 
     total_page = int(ceil(cnt_logs / float(limit)))
@@ -160,7 +161,7 @@ def admin_actions():
             status=status,
             count=True
         )
-    except pkgdblib.PkgdbException as err:
+    except PkgdbException as err:
         flask.flash(err, 'errors')
 
     total_page = int(ceil(cnt_actions / float(limit)))
@@ -215,7 +216,7 @@ def admin_action_edit_status(action_id):
             )
             SESSION.commit()
             flask.flash(message)
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             # We can only reach here in two cases:
             # 1) the user is not an admin, but that's taken care of
             #    by the decorator
@@ -270,7 +271,7 @@ def admin_drop_namespace():
             )
             SESSION.commit()
             flask.flash(message)
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             # We can only reach here in two cases:
             # 1) the user is not an admin, but that's taken care of
             #    by the decorator
@@ -301,7 +302,7 @@ def admin_add_namespace():
             )
             SESSION.commit()
             flask.flash(message)
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             # We can only reach here in two cases:
             # 1) the user is not an admin, but that's taken care of
             #    by the decorator

--- a/pkgdb2/ui/collections.py
+++ b/pkgdb2/ui/collections.py
@@ -30,6 +30,7 @@ import pkgdb2.forms
 import pkgdb2.lib as pkgdblib
 from pkgdb2 import SESSION, APP, is_admin
 from pkgdb2.ui import UI
+from pkgdb2.lib.exceptions import PkgdbException
 
 
 ## Some of the object we use here have inherited methods which apparently
@@ -136,7 +137,7 @@ def collection_edit(collection):
             return flask.redirect(flask.url_for(
                 '.collection_info', collection=collection.branchname))
         # In theory we should never hit this
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'errors')
     elif flask.request.method == 'GET':
@@ -184,7 +185,7 @@ def collection_new():
             flask.flash(message)
             return flask.redirect(flask.url_for('.list_collections'))
         # In theory we should never hit this
-        except pkgdblib.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'errors')
 

--- a/pkgdb2/ui/collections.py
+++ b/pkgdb2/ui/collections.py
@@ -136,7 +136,7 @@ def collection_edit(collection):
             return flask.redirect(flask.url_for(
                 '.collection_info', collection=collection.branchname))
         # In theory we should never hit this
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'errors')
     elif flask.request.method == 'GET':
@@ -184,7 +184,7 @@ def collection_new():
             flask.flash(message)
             return flask.redirect(flask.url_for('.list_collections'))
         # In theory we should never hit this
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'errors')
 

--- a/pkgdb2/ui/packagers.py
+++ b/pkgdb2/ui/packagers.py
@@ -29,6 +29,7 @@ from math import ceil
 import pkgdb2.lib as pkgdblib
 from pkgdb2 import SESSION, APP
 from pkgdb2.ui import UI
+from pkgdb2.lib.exceptions import PkgdbException
 
 
 @UI.route('/packagers/')
@@ -174,7 +175,7 @@ def packager_requests(packager):
             limit=limit,
             count=True,
         )
-    except pkgdblib.PkgdbException as err:
+    except PkgdbException as err:
         flask.flash(err, 'errors')
 
     total_page = int(ceil(cnt_actions / float(limit)))

--- a/pkgdb2/ui/packagers.py
+++ b/pkgdb2/ui/packagers.py
@@ -174,7 +174,7 @@ def packager_requests(packager):
             limit=limit,
             count=True,
         )
-    except pkgdblib.PkgdbException, err:
+    except pkgdblib.PkgdbException as err:
         flask.flash(err, 'errors')
 
     total_page = int(ceil(cnt_actions / float(limit)))

--- a/pkgdb2/ui/packages.py
+++ b/pkgdb2/ui/packages.py
@@ -317,7 +317,7 @@ def package_timeline(namespace, package):
             from_date=from_date,
             count=True
         )
-    except pkgdblib.exceptions.PkgdbException, err:
+    except pkgdblib.exceptions.PkgdbException as err:
         flask.flash(err, 'errors')
 
     total_page = int(ceil(cnt_logs / float(limit)))
@@ -365,7 +365,7 @@ def package_anitya(namespace, package, full=True):
                 'Querying anitya returned a status %s' % req.status_code)
         else:
             data = req.json()
-    except Exception, err:
+    except Exception as err:
         flask.flash(err.message, 'error')
         pass
 
@@ -455,7 +455,7 @@ def package_request_edit(action_id):
             )
             SESSION.commit()
             flask.flash(message)
-        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
             # We can only reach here in two cases:
             # 1) the user is not an admin, but that's taken care of
             #    by the decorator
@@ -537,7 +537,7 @@ def package_new():
             flask.flash(message)
             return flask.redirect(flask.url_for('.list_packages'))
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -619,11 +619,11 @@ def package_give(namespace, package, full=True):
                     )
 
                 SESSION.commit()
-        except pkgdblib.exceptions.PkgdbBugzillaException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbBugzillaException as err:  # pragma: no cover
             APP.logger.exception(err)
             flask.flash(str(err), 'error')
             SESSION.rollback()
-        except pkgdblib.exceptions.PkgdbException, err:
+        except pkgdblib.exceptions.PkgdbException as err:
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -692,18 +692,18 @@ def package_orphan(namespace, package, full=True):
                 flask.flash(
                     'You are no longer point of contact on branch: %s'
                     % branch)
-            except pkgdblib.exceptions.PkgdbBugzillaException, err:  # pragma: no cover
+            except pkgdblib.exceptions.PkgdbBugzillaException as err:  # pragma: no cover
                 APP.logger.exception(err)
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
-            except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+            except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
 
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -776,7 +776,7 @@ def package_retire(namespace, package, full=True):
                         flask.flash(
                             'This package has been retired on branch: %s'
                             % acl.collection.branchname)
-                    except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+                    except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
                         # We should never hit this
                         flask.flash(str(err), 'error')
                         SESSION.rollback()
@@ -789,7 +789,7 @@ def package_retire(namespace, package, full=True):
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
             # We should never hit this
             SESSION.rollback()
             APP.logger.exception(err)
@@ -905,11 +905,11 @@ def package_unretire(namespace, package, full=True):
                         flask.flash(
                             'Admins have been asked to un-retire branch: %s'
                             % acl.collection.branchname)
-                    except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+                    except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
                         # We should never hit this
                         flask.flash(str(err), 'error')
                         SESSION.rollback()
-                    except SQLAlchemyError, err:
+                    except SQLAlchemyError as err:
                         APP.logger.exception(err)
                         SESSION.rollback()
                         flask.flash(
@@ -924,7 +924,7 @@ def package_unretire(namespace, package, full=True):
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
             # We should never hit this
             SESSION.rollback()
             APP.logger.exception(err)
@@ -995,11 +995,11 @@ def package_take(namespace, package, full=True):
                 SESSION.commit()
                 flask.flash('You have taken the package %s on branch %s' % (
                     package.name, branch))
-            except pkgdblib.exceptions.PkgdbBugzillaException, err:  # pragma: no cover
+            except pkgdblib.exceptions.PkgdbBugzillaException as err:  # pragma: no cover
                 APP.logger.exception(err)
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
-            except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+            except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
 
@@ -1163,7 +1163,7 @@ def update_acl(namespace, package, update_acl):
                         flask.flash("%s's %s ACL updated on %s" % (
                             lcl_user, update_acl, lcl_branch))
                         changed = True
-                    except pkgdblib.exceptions.PkgdbException, err:
+                    except pkgdblib.exceptions.PkgdbException as err:
                         SESSION.rollback()
                         flask.flash(str(err), 'error')
                     cnt += 1
@@ -1236,7 +1236,7 @@ def delete_package(namespace, package):
     try:
         SESSION.commit()
         flask.flash('Package %s deleted' % packagename)
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         SESSION.rollback()
         flask.flash(
             'An error occured while trying to delete the package %s'
@@ -1307,10 +1307,10 @@ def package_request_branch(namespace, package, full=True):
                     user=flask.g.fas_user)
                 SESSION.commit()
                 flask.flash(msg)
-            except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+            except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
-            except SQLAlchemyError, err:  # pragma: no cover
+            except SQLAlchemyError as err:  # pragma: no cover
                 APP.logger.exception(err)
                 flask.flash(
                     'Could not save the request to the database for '
@@ -1412,7 +1412,7 @@ def package_request_new():
                 flask.flash(message)
             return flask.redirect(flask.url_for('.index'))
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 

--- a/pkgdb2/ui/packages.py
+++ b/pkgdb2/ui/packages.py
@@ -317,7 +317,7 @@ def package_timeline(namespace, package):
             from_date=from_date,
             count=True
         )
-    except pkgdblib.PkgdbException, err:
+    except pkgdblib.exceptions.PkgdbException, err:
         flask.flash(err, 'errors')
 
     total_page = int(ceil(cnt_logs / float(limit)))
@@ -361,7 +361,7 @@ def package_anitya(namespace, package, full=True):
     try:
         req = requests.get(url)
         if req.status_code != 200:
-            raise pkgdblib.PkgdbException(
+            raise pkgdblib.exceptions.PkgdbException(
                 'Querying anitya returned a status %s' % req.status_code)
         else:
             data = req.json()
@@ -455,7 +455,7 @@ def package_request_edit(action_id):
             )
             SESSION.commit()
             flask.flash(message)
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
             # We can only reach here in two cases:
             # 1) the user is not an admin, but that's taken care of
             #    by the decorator
@@ -537,7 +537,7 @@ def package_new():
             flask.flash(message)
             return flask.redirect(flask.url_for('.list_packages'))
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -619,11 +619,11 @@ def package_give(namespace, package, full=True):
                     )
 
                 SESSION.commit()
-        except pkgdblib.PkgdbBugzillaException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbBugzillaException, err:  # pragma: no cover
             APP.logger.exception(err)
             flask.flash(str(err), 'error')
             SESSION.rollback()
-        except pkgdblib.PkgdbException, err:
+        except pkgdblib.exceptions.PkgdbException, err:
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -692,18 +692,18 @@ def package_orphan(namespace, package, full=True):
                 flask.flash(
                     'You are no longer point of contact on branch: %s'
                     % branch)
-            except pkgdblib.PkgdbBugzillaException, err:  # pragma: no cover
+            except pkgdblib.exceptions.PkgdbBugzillaException, err:  # pragma: no cover
                 APP.logger.exception(err)
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
-            except pkgdblib.PkgdbException, err:  # pragma: no cover
+            except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
 
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -776,7 +776,7 @@ def package_retire(namespace, package, full=True):
                         flask.flash(
                             'This package has been retired on branch: %s'
                             % acl.collection.branchname)
-                    except pkgdblib.PkgdbException, err:  # pragma: no cover
+                    except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
                         # We should never hit this
                         flask.flash(str(err), 'error')
                         SESSION.rollback()
@@ -789,7 +789,7 @@ def package_retire(namespace, package, full=True):
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
             # We should never hit this
             SESSION.rollback()
             APP.logger.exception(err)
@@ -905,7 +905,7 @@ def package_unretire(namespace, package, full=True):
                         flask.flash(
                             'Admins have been asked to un-retire branch: %s'
                             % acl.collection.branchname)
-                    except pkgdblib.PkgdbException, err:  # pragma: no cover
+                    except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
                         # We should never hit this
                         flask.flash(str(err), 'error')
                         SESSION.rollback()
@@ -924,7 +924,7 @@ def package_unretire(namespace, package, full=True):
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
             # We should never hit this
             SESSION.rollback()
             APP.logger.exception(err)
@@ -995,11 +995,11 @@ def package_take(namespace, package, full=True):
                 SESSION.commit()
                 flask.flash('You have taken the package %s on branch %s' % (
                     package.name, branch))
-            except pkgdblib.PkgdbBugzillaException, err:  # pragma: no cover
+            except pkgdblib.exceptions.PkgdbBugzillaException, err:  # pragma: no cover
                 APP.logger.exception(err)
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
-            except pkgdblib.PkgdbException, err:  # pragma: no cover
+            except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
 
@@ -1163,7 +1163,7 @@ def update_acl(namespace, package, update_acl):
                         flask.flash("%s's %s ACL updated on %s" % (
                             lcl_user, update_acl, lcl_branch))
                         changed = True
-                    except pkgdblib.PkgdbException, err:
+                    except pkgdblib.exceptions.PkgdbException, err:
                         SESSION.rollback()
                         flask.flash(str(err), 'error')
                     cnt += 1
@@ -1307,7 +1307,7 @@ def package_request_branch(namespace, package, full=True):
                     user=flask.g.fas_user)
                 SESSION.commit()
                 flask.flash(msg)
-            except pkgdblib.PkgdbException, err:  # pragma: no cover
+            except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
             except SQLAlchemyError, err:  # pragma: no cover
@@ -1412,7 +1412,7 @@ def package_request_new():
                 flask.flash(message)
             return flask.redirect(flask.url_for('.index'))
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.PkgdbException, err:  # pragma: no cover
+        except pkgdblib.exceptions.PkgdbException, err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 

--- a/pkgdb2/ui/packages.py
+++ b/pkgdb2/ui/packages.py
@@ -35,6 +35,7 @@ import pkgdb2.lib as pkgdblib
 from pkgdb2 import SESSION, APP, is_admin, is_pkgdb_admin, is_pkg_admin, \
     packager_login_required, is_authenticated
 from pkgdb2.ui import UI
+from pkgdb2.lib.exceptions import PkgdbException
 
 
 ## Some of the object we use here have inherited methods which apparently
@@ -317,7 +318,7 @@ def package_timeline(namespace, package):
             from_date=from_date,
             count=True
         )
-    except pkgdblib.exceptions.PkgdbException as err:
+    except PkgdbException as err:
         flask.flash(err, 'errors')
 
     total_page = int(ceil(cnt_logs / float(limit)))
@@ -361,7 +362,7 @@ def package_anitya(namespace, package, full=True):
     try:
         req = requests.get(url)
         if req.status_code != 200:
-            raise pkgdblib.exceptions.PkgdbException(
+            raise PkgdbException(
                 'Querying anitya returned a status %s' % req.status_code)
         else:
             data = req.json()
@@ -455,7 +456,7 @@ def package_request_edit(action_id):
             )
             SESSION.commit()
             flask.flash(message)
-        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             # We can only reach here in two cases:
             # 1) the user is not an admin, but that's taken care of
             #    by the decorator
@@ -537,7 +538,7 @@ def package_new():
             flask.flash(message)
             return flask.redirect(flask.url_for('.list_packages'))
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -623,7 +624,7 @@ def package_give(namespace, package, full=True):
             APP.logger.exception(err)
             flask.flash(str(err), 'error')
             SESSION.rollback()
-        except pkgdblib.exceptions.PkgdbException as err:
+        except PkgdbException as err:
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -696,14 +697,14 @@ def package_orphan(namespace, package, full=True):
                 APP.logger.exception(err)
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
-            except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+            except PkgdbException as err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
 
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 
@@ -776,7 +777,7 @@ def package_retire(namespace, package, full=True):
                         flask.flash(
                             'This package has been retired on branch: %s'
                             % acl.collection.branchname)
-                    except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+                    except PkgdbException as err:  # pragma: no cover
                         # We should never hit this
                         flask.flash(str(err), 'error')
                         SESSION.rollback()
@@ -789,7 +790,7 @@ def package_retire(namespace, package, full=True):
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             # We should never hit this
             SESSION.rollback()
             APP.logger.exception(err)
@@ -905,7 +906,7 @@ def package_unretire(namespace, package, full=True):
                         flask.flash(
                             'Admins have been asked to un-retire branch: %s'
                             % acl.collection.branchname)
-                    except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+                    except PkgdbException as err:  # pragma: no cover
                         # We should never hit this
                         flask.flash(str(err), 'error')
                         SESSION.rollback()
@@ -924,7 +925,7 @@ def package_unretire(namespace, package, full=True):
         try:
             SESSION.commit()
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             # We should never hit this
             SESSION.rollback()
             APP.logger.exception(err)
@@ -999,7 +1000,7 @@ def package_take(namespace, package, full=True):
                 APP.logger.exception(err)
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
-            except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+            except PkgdbException as err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
 
@@ -1163,7 +1164,7 @@ def update_acl(namespace, package, update_acl):
                         flask.flash("%s's %s ACL updated on %s" % (
                             lcl_user, update_acl, lcl_branch))
                         changed = True
-                    except pkgdblib.exceptions.PkgdbException as err:
+                    except PkgdbException as err:
                         SESSION.rollback()
                         flask.flash(str(err), 'error')
                     cnt += 1
@@ -1307,7 +1308,7 @@ def package_request_branch(namespace, package, full=True):
                     user=flask.g.fas_user)
                 SESSION.commit()
                 flask.flash(msg)
-            except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+            except PkgdbException as err:  # pragma: no cover
                 flask.flash(str(err), 'error')
                 SESSION.rollback()
             except SQLAlchemyError as err:  # pragma: no cover
@@ -1412,7 +1413,7 @@ def package_request_new():
                 flask.flash(message)
             return flask.redirect(flask.url_for('.index'))
         # Keep it in, but normally we shouldn't hit this
-        except pkgdblib.exceptions.PkgdbException as err:  # pragma: no cover
+        except PkgdbException as err:  # pragma: no cover
             SESSION.rollback()
             flask.flash(str(err), 'error')
 

--- a/tests/test_pkgdblib.py
+++ b/tests/test_pkgdblib.py
@@ -2338,6 +2338,26 @@ class PkgdbLibtests(Modeltests):
             self.session, 'namespaces')['namespaces']
         self.assertEqual(namespaces, ['docker', 'modules', 'rpms'])
 
+    def test_check_bz_url(self):
+        BZ_BASE = "https://example.com"
+        EXPECTED_URL = "https://example.com/12345"
+
+        result = pkgdblib.check_bz_url(BZ_BASE, EXPECTED_URL)
+        self.assertEqual(result, EXPECTED_URL)
+
+        result = pkgdblib.check_bz_url(
+            BZ_BASE, "https://example.com/show_bug.cgi?id=12345")
+        self.assertEqual(result, EXPECTED_URL)
+
+        result = pkgdblib.check_bz_url(BZ_BASE, "12345")
+        self.assertEqual(result, EXPECTED_URL)
+
+        result = pkgdblib.check_bz_url(BZ_BASE, "https://example.com/")
+        self.assertEqual(result, None)
+
+        result = pkgdblib.check_bz_url(BZ_BASE, "")
+        self.assertEqual(result, None)
+
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(PkgdbLibtests)

--- a/tests/test_pkgdblib.py
+++ b/tests/test_pkgdblib.py
@@ -46,6 +46,7 @@ from tests import (FakeFasUser, FakeFasUserAdmin, Modeltests,
                    FakeFasGroupValid, FakeFasGroupInvalid,
                    create_collection, create_package_acl,
                    create_package_acl2, create_package_critpath)
+from pkgdb2.lib.exceptions import PkgdbException
 
 
 class PkgdbLibtests(Modeltests):
@@ -58,7 +59,7 @@ class PkgdbLibtests(Modeltests):
 
         mock_func.return_value = 1
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.add_package,
                           self.session,
                           namespace='rpms',
@@ -74,7 +75,7 @@ class PkgdbLibtests(Modeltests):
                           )
         self.session.rollback()
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.add_package,
                           self.session,
                           namespace='rpms',
@@ -94,7 +95,7 @@ class PkgdbLibtests(Modeltests):
         pkgdb2.lib.utils.get_packagers.reset_mock()
 
         # Configuration to query FAS isn't set
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.add_package,
                           self.session,
                           namespace='rpms',
@@ -112,7 +113,7 @@ class PkgdbLibtests(Modeltests):
         pkgdb2.lib.utils.get_packagers.return_value = ['pingou']
 
         # 'Ralph' is not in the packager group
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.add_package,
                           self.session,
                           namespace='rpms',
@@ -130,7 +131,7 @@ class PkgdbLibtests(Modeltests):
         pkgdb2.lib.utils.get_fas_group.return_value = FakeFasGroupInvalid
 
         # Invalid FAS group, not ending with -sig
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.add_package,
                           self.session,
                           namespace='rpms',
@@ -145,7 +146,7 @@ class PkgdbLibtests(Modeltests):
                           user=FakeFasUserAdmin())
 
         # Invalid FAS group returned
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.add_package,
                           self.session,
                           namespace='rpms',
@@ -266,7 +267,7 @@ class PkgdbLibtests(Modeltests):
         mock_func.return_value = 1
 
         # Not allowed to set acl on non-existant package
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.set_acl_package,
                           self.session,
                           namespace='rpms',
@@ -280,7 +281,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Not allowed to set non-existant collection
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.set_acl_package,
                           self.session,
                           namespace='rpms',
@@ -322,7 +323,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Not allowed to set acl for yourself
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.set_acl_package,
                           self.session,
                           namespace='rpms',
@@ -336,7 +337,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Not allowed to set acl for someone else
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.set_acl_package,
                           self.session,
                           namespace='rpms',
@@ -350,7 +351,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Not allowed to set acl approveacl to a group
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.set_acl_package,
                           self.session,
                           namespace='rpms',
@@ -364,7 +365,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Group must ends with -sig
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.set_acl_package,
                           self.session,
                           namespace='rpms',
@@ -378,7 +379,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Group cannot have approveacls
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.set_acl_package,
                           self.session,
                           namespace='rpms',
@@ -414,7 +415,7 @@ class PkgdbLibtests(Modeltests):
 
         # Adding non-auto-approve ACL should not work fine
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.set_acl_package,
             self.session,
             namespace='rpms',
@@ -503,7 +504,7 @@ class PkgdbLibtests(Modeltests):
         mock_func.get_fas_group.return_value = FakeFasGroupValid()
 
         # Package must exists
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_poc,
                           self.session,
                           namespace='rpms',
@@ -515,7 +516,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Collection must exists
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_poc,
                           self.session,
                           namespace='rpms',
@@ -528,7 +529,7 @@ class PkgdbLibtests(Modeltests):
 
         # User must be the actual Point of Contact (or an admin of course,
         # or part of the group)
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_poc,
                           self.session,
                           namespace='rpms',
@@ -558,7 +559,7 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(pkg_acl[0].point_of_contact, 'group::perl-sig')
 
         # User must be in the group it takes the PoC from
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_poc,
                           self.session,
                           namespace='rpms',
@@ -572,7 +573,7 @@ class PkgdbLibtests(Modeltests):
         # User must be in the POC of the branch specified
         user = FakeFasUser()
         user.username = 'ralph'
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_poc,
                           self.session,
                           namespace='rpms',
@@ -618,7 +619,7 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(pkg_acl[0].point_of_contact, 'toshio')
 
         # PoC must be a packager, even for admin
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_poc,
                           self.session,
                           namespace='rpms',
@@ -807,7 +808,7 @@ class PkgdbLibtests(Modeltests):
                                        )
         self.assertEqual(len(pkgs), 0)
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.search_package,
                           self.session,
                           namespace='rpms',
@@ -819,7 +820,7 @@ class PkgdbLibtests(Modeltests):
                           limit='a'
                           )
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.search_package,
                           self.session,
                           namespace='rpms',
@@ -836,7 +837,7 @@ class PkgdbLibtests(Modeltests):
         create_package_acl(self.session)
 
         # Wrong package
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_status,
                           self.session,
                           namespace='rpms',
@@ -848,7 +849,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Wrong collection
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_status,
                           self.session,
                           namespace='rpms',
@@ -860,7 +861,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # User not allowed to retire the package on f18
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_status,
                           self.session,
                           namespace='rpms',
@@ -872,7 +873,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Wrong status
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_status,
                           self.session,
                           namespace='rpms',
@@ -884,7 +885,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # User not allowed to change status to Allowed
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_status,
                           self.session,
                           namespace='rpms',
@@ -930,7 +931,7 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(pkg_acl[1].status, 'Orphaned')
 
         # Admin must give a poc when un-orphan/un-retire a package
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_status,
                           self.session,
                           namespace='rpms',
@@ -991,7 +992,7 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(pkg_acl[1].status, 'Approved')
 
         # Not Admin and status is not Orphaned nor Retired
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_pkg_status,
                           self.session,
                           namespace='rpms',
@@ -1025,7 +1026,7 @@ class PkgdbLibtests(Modeltests):
             limit=1)
         self.assertEqual(len(collections), 1)
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.search_collection,
                           self.session,
                           'f*',
@@ -1039,7 +1040,7 @@ class PkgdbLibtests(Modeltests):
             page=2)
         self.assertEqual(len(collections), 1)
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.search_collection,
                           self.session,
                           'f*',
@@ -1049,7 +1050,7 @@ class PkgdbLibtests(Modeltests):
     def test_add_collection(self):
         """ Test the add_collection function. """
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.add_collection,
                           session=self.session,
                           clt_name='Fedora',
@@ -1086,7 +1087,7 @@ class PkgdbLibtests(Modeltests):
         collection = pkgdblib.model.Collection.by_name(self.session, 'f18')
         self.assertEqual(collection.status, 'Active')
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.update_collection_status,
                           self.session,
                           'f18',
@@ -1124,14 +1125,14 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(len(pkg), 1)
         self.assertEqual(pkg[0][0], 'pingou')
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.search_packagers,
                           self.session,
                           'p*',
                           limit='a'
                           )
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.search_packagers,
                           self.session,
                           'p*',
@@ -1157,7 +1158,7 @@ class PkgdbLibtests(Modeltests):
 
         # Wrong page provided
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.get_acl_packager,
             self.session,
             'pingou',
@@ -1364,7 +1365,7 @@ class PkgdbLibtests(Modeltests):
                                        user=FakeFasUserAdmin())
         self.assertEqual(out, None)
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.edit_collection,
                           self.session,
                           collection)
@@ -1399,7 +1400,7 @@ class PkgdbLibtests(Modeltests):
             self.session, package, user=FakeFasUserAdmin())
         self.assertEqual(out, None)
 
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.edit_package,
                           self.session,
                           package)
@@ -1449,21 +1450,21 @@ class PkgdbLibtests(Modeltests):
         self.test_add_package()
 
         # Wrong limit
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.search_logs,
                           self.session,
                           limit='a'
                           )
 
         # Wrong offset
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.search_logs,
                           self.session,
                           page='a'
                           )
 
         # Wrong package name
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.search_logs,
                           self.session,
                           package='asdads'
@@ -1516,7 +1517,7 @@ class PkgdbLibtests(Modeltests):
         create_package_acl(self.session)
 
         # Wrong package name
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.unorphan_package,
                           self.session,
                           namespace='rpms',
@@ -1528,7 +1529,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Wrong collection
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.unorphan_package,
                           self.session,
                           namespace='rpms',
@@ -1540,7 +1541,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # Package is not orphaned
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.unorphan_package,
                           self.session,
                           namespace='rpms',
@@ -1552,7 +1553,7 @@ class PkgdbLibtests(Modeltests):
         self.session.rollback()
 
         # PKGDB2_BUGZILLA_* configuration not set
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.unorphan_package,
                           self.session,
                           namespace='rpms',
@@ -1581,7 +1582,7 @@ class PkgdbLibtests(Modeltests):
         self.session.commit()
 
         # User cannot unorphan for someone else
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.unorphan_package,
                           self.session,
                           namespace='rpms',
@@ -1595,7 +1596,7 @@ class PkgdbLibtests(Modeltests):
         # User must be a packager
         user = FakeFasUser()
         user.groups = ['cla_done']
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.unorphan_package,
                           self.session,
                           namespace='rpms',
@@ -1660,7 +1661,7 @@ class PkgdbLibtests(Modeltests):
         self.session.commit()
 
         # User cannot branch, admins are required
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.add_branch,
                           session=self.session,
                           clt_from='master',
@@ -1669,7 +1670,7 @@ class PkgdbLibtests(Modeltests):
                           )
 
         # Inexistant collection to branch from
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.add_branch,
                           session=self.session,
                           clt_from='blah',
@@ -1678,7 +1679,7 @@ class PkgdbLibtests(Modeltests):
                           )
 
         # Inexistant collection to branch to
-        self.assertRaises(pkgdblib.PkgdbException,
+        self.assertRaises(PkgdbException,
                           pkgdblib.add_branch,
                           session=self.session,
                           clt_from='master',
@@ -1757,7 +1758,7 @@ class PkgdbLibtests(Modeltests):
     def test_set_critpath_packages(self):
         """ Test the set_critpath_packages function. """
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.set_critpath_packages,
             session=self.session,
             namespace='rpms',
@@ -1770,7 +1771,7 @@ class PkgdbLibtests(Modeltests):
         create_package_critpath(self.session)
 
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.set_critpath_packages,
             session=self.session,
             namespace='rpms',
@@ -1812,7 +1813,7 @@ class PkgdbLibtests(Modeltests):
 
         # Fails: package not found
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.set_monitor_package,
             session=self.session,
             namespace='rpms',
@@ -1832,7 +1833,7 @@ class PkgdbLibtests(Modeltests):
         user = FakeFasUser()
         user.username = 'Toshio'
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.set_monitor_package,
             session=self.session,
             namespace='rpms',
@@ -1889,7 +1890,7 @@ class PkgdbLibtests(Modeltests):
 
         # Invalid package
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_new_branch_request,
             session=self.session,
             namespace='rpms',
@@ -1900,7 +1901,7 @@ class PkgdbLibtests(Modeltests):
 
         # Invalid collection_to
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_new_branch_request,
             session=self.session,
             namespace='rpms',
@@ -1911,7 +1912,7 @@ class PkgdbLibtests(Modeltests):
 
         # Invalid collection_from
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_new_branch_request,
             session=self.session,
             namespace='rpms',
@@ -1922,7 +1923,7 @@ class PkgdbLibtests(Modeltests):
 
         # violation of namespace policy
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_new_branch_request,
             session=self.session,
             namespace='modules',
@@ -1950,7 +1951,7 @@ class PkgdbLibtests(Modeltests):
 
         # Wrong limit
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.search_actions,
             self.session,
             limit='a'
@@ -1958,7 +1959,7 @@ class PkgdbLibtests(Modeltests):
 
         # Wrong offset
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.search_actions,
             self.session,
             page='a'
@@ -1966,7 +1967,7 @@ class PkgdbLibtests(Modeltests):
 
         # Wrong package name
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.search_actions,
             self.session,
             package='asdads'
@@ -2059,7 +2060,7 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(action.info, None)
 
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.edit_action_status,
             self.session,
             admin_action=action,
@@ -2070,7 +2071,7 @@ class PkgdbLibtests(Modeltests):
         action = pkgdblib.get_admin_action(self.session, 1)
 
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.edit_action_status,
             self.session,
             admin_action=action,
@@ -2082,7 +2083,7 @@ class PkgdbLibtests(Modeltests):
         user = FakeFasUser()
         user.username = 'shaiton'
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.edit_action_status,
             self.session,
             admin_action=action,
@@ -2094,7 +2095,7 @@ class PkgdbLibtests(Modeltests):
         user = FakeFasUser()
         user.username = 'toshio'
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.edit_action_status,
             self.session,
             admin_action=action,
@@ -2105,7 +2106,7 @@ class PkgdbLibtests(Modeltests):
         # Obsolete status but user is not requester
         user = FakeFasUserAdmin()
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.edit_action_status,
             self.session,
             admin_action=action,
@@ -2154,7 +2155,7 @@ class PkgdbLibtests(Modeltests):
         mock_func.return_value = ['pingou']
 
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_unretire_request,
             self.session,
             namespace='rpms',
@@ -2168,7 +2169,7 @@ class PkgdbLibtests(Modeltests):
         self.session.commit()
 
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_unretire_request,
             self.session,
             namespace='rpms',
@@ -2198,7 +2199,7 @@ class PkgdbLibtests(Modeltests):
 
         # Branch `foo` not found
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_new_package_request,
             session=self.session,
             pkg_name='guake',
@@ -2218,7 +2219,7 @@ class PkgdbLibtests(Modeltests):
 
         # Again, branch not found
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_new_package_request,
             session=self.session,
             pkg_name='guake',
@@ -2235,7 +2236,7 @@ class PkgdbLibtests(Modeltests):
 
         # Package already exists
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_new_package_request,
             session=self.session,
             pkg_name='guake',
@@ -2276,7 +2277,7 @@ class PkgdbLibtests(Modeltests):
         # User is not an admin
         user = FakeFasUser()
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_namespace,
             self.session,
             'foo',
@@ -2285,7 +2286,7 @@ class PkgdbLibtests(Modeltests):
 
         # Namespace already exists
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.add_namespace,
             self.session,
             'rpms',
@@ -2319,7 +2320,7 @@ class PkgdbLibtests(Modeltests):
         # User is not an admin
         user = FakeFasUser()
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.drop_namespace,
             self.session,
             'foo',
@@ -2328,7 +2329,7 @@ class PkgdbLibtests(Modeltests):
 
         # Namespace does not exist
         self.assertRaises(
-            pkgdblib.PkgdbException,
+            PkgdbException,
             pkgdblib.drop_namespace,
             self.session,
             'foobar',

--- a/tests/test_pkgdblib.py
+++ b/tests/test_pkgdblib.py
@@ -232,7 +232,8 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(pkg_acl[0].acls[0].fas_name, 'pingou')
 
         # No EOL collection, so no change
-        pkg_acl = pkgdblib.get_acl_package(self.session, 'rpms', 'guake', eol=True)
+        pkg_acl = pkgdblib.get_acl_package(self.session, 'rpms', 'guake',
+                                           eol=True)
         self.assertEqual(len(pkg_acl), 2)
         self.assertEqual(pkg_acl[0].collection.branchname, 'f18')
         self.assertEqual(pkg_acl[0].package.name, 'guake')
@@ -1149,8 +1150,10 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(acls[0][0].packagelist.package.name, 'guake')
         self.assertEqual(acls[0][0].packagelist.collection.branchname, 'f18')
         self.assertEqual(acls[1][0].packagelist.collection.branchname, 'f18')
-        self.assertEqual(acls[2][0].packagelist.collection.branchname, 'master')
-        self.assertEqual(acls[3][0].packagelist.collection.branchname, 'master')
+        self.assertEqual(acls[2][0].packagelist.collection.branchname,
+                         'master')
+        self.assertEqual(acls[3][0].packagelist.collection.branchname,
+                         'master')
 
         # Wrong page provided
         self.assertRaises(
@@ -1166,15 +1169,18 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(acls[0][0].packagelist.package.name, 'guake')
         self.assertEqual(acls[0][0].packagelist.collection.branchname, 'f18')
         self.assertEqual(acls[1][0].packagelist.package.name, 'guake')
-        self.assertEqual(acls[1][0].packagelist.collection.branchname, 'master')
+        self.assertEqual(acls[1][0].packagelist.collection.branchname,
+                         'master')
 
         acls = pkgdblib.get_acl_packager(
             self.session, 'pingou', acls='commit', page=2, limit=2)
         self.assertEqual(len(acls), 2)
         self.assertEqual(acls[0][0].packagelist.package.name, 'geany')
-        self.assertEqual(acls[0][0].packagelist.collection.branchname, 'master')
+        self.assertEqual(acls[0][0].packagelist.collection.branchname,
+                         'master')
         self.assertEqual(acls[1][0].packagelist.package.name, 'fedocal')
-        self.assertEqual(acls[1][0].packagelist.collection.branchname, 'master')
+        self.assertEqual(acls[1][0].packagelist.collection.branchname,
+                         'master')
 
         acls = pkgdblib.get_acl_packager(
             self.session, 'pingou', acls=['commit', 'watchbugzilla'])
@@ -1182,7 +1188,8 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(acls[0][0].packagelist.package.name, 'guake')
         self.assertEqual(acls[0][0].packagelist.collection.branchname, 'f18')
         self.assertEqual(acls[1][0].packagelist.package.name, 'guake')
-        self.assertEqual(acls[1][0].packagelist.collection.branchname, 'master')
+        self.assertEqual(acls[1][0].packagelist.collection.branchname,
+                         'master')
 
         acls = pkgdblib.get_acl_packager(
             self.session, 'pingou', acls=['commit'], poc=True)
@@ -1190,15 +1197,18 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(acls[0][0].packagelist.package.name, 'guake')
         self.assertEqual(acls[0][0].packagelist.collection.branchname, 'f18')
         self.assertEqual(acls[1][0].packagelist.package.name, 'guake')
-        self.assertEqual(acls[1][0].packagelist.collection.branchname, 'master')
+        self.assertEqual(acls[1][0].packagelist.collection.branchname,
+                         'master')
 
         acls = pkgdblib.get_acl_packager(
             self.session, 'pingou', acls=['commit'], poc=False)
         self.assertEqual(len(acls), 3)
         self.assertEqual(acls[0][0].packagelist.package.name, 'geany')
-        self.assertEqual(acls[0][0].packagelist.collection.branchname, 'master')
+        self.assertEqual(acls[0][0].packagelist.collection.branchname,
+                         'master')
         self.assertEqual(acls[1][0].packagelist.package.name, 'fedocal')
-        self.assertEqual(acls[1][0].packagelist.collection.branchname, 'master')
+        self.assertEqual(acls[1][0].packagelist.collection.branchname,
+                         'master')
         self.assertEqual(acls[2][0].packagelist.package.name, 'fedocal')
         self.assertEqual(acls[2][0].packagelist.collection.branchname, 'f18')
 
@@ -1267,7 +1277,8 @@ class PkgdbLibtests(Modeltests):
         self.assertFalse(pkgdblib.has_acls(
             self.session, 'toshio', 'rpms', 'guake', acl='commit'))
         self.assertFalse(pkgdblib.has_acls(
-            self.session, 'toshio', 'rpms', 'guake', acl=['commit', 'approveacls']))
+            self.session, 'toshio', 'rpms', 'guake', acl=['commit',
+                                                          'approveacls']))
 
     def test_get_status(self):
         """ Test the get_status function. """
@@ -1486,7 +1497,8 @@ class PkgdbLibtests(Modeltests):
         logs = pkgdblib.search_logs(self.session, count=True)
         self.assertEqual(logs, 23)
 
-        logs = pkgdblib.search_logs(self.session, from_date=datetime.utcnow().date())
+        logs = pkgdblib.search_logs(self.session,
+                                    from_date=datetime.utcnow().date())
         self.assertEqual(len(logs), 23)
 
         logs = pkgdblib.search_logs(
@@ -1634,7 +1646,6 @@ class PkgdbLibtests(Modeltests):
         self.assertEqual(pkg_acl[0].package.name, 'core')
         self.assertEqual(pkg_acl[0].acls[0].fas_name, 'josef')
         self.assertEqual(len(pkg_acl[0].acls), 3)
-
 
         # Create a new collection
         new_collection = pkgdblib.model.Collection(


### PR DESCRIPTION
This PR first fixes the test suite to not report errors because of undefined exceptions, adds a test for the function to identify the probem, fixes the problem and also fixes some PEP8 violations in the touched files.

This should fix the problem in  https://fedorahosted.org/rel-eng/ticket/6426