### PR TITLE
Expand the field fas_name from PackageListingAcl from 32 to 255 chars

### DIFF
--- a/alembic/versions/187e9f9ec178_expand_fas_name_to_255_chars.py
+++ b/alembic/versions/187e9f9ec178_expand_fas_name_to_255_chars.py
@@ -1,0 +1,36 @@
+"""Expand fas_name to 255 chars
+
+Revision ID: 187e9f9ec178
+Revises: 27924040e3ad
+Create Date: 2016-07-07 19:54:21.331838
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '187e9f9ec178'
+down_revision = '27924040e3ad'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    """ Update the fas_name column of PackageListingAcl from 32 chars to 255
+    """
+    op.alter_column(
+        table_name='PackageListingAcl',
+        column_name='fas_name',
+        type_=sa.String(255),
+        existing_type=sa.String(32)
+    )
+
+
+def downgrade():
+    """ Update the fas_name column of PackageListingAcl from 255 chars to 32
+    """
+     op.alter_column(
+        table_name='PackageListingAcl',
+        column_name='fas_name',
+        type_=sa.String(32),
+        existing_type=sa.String(255)
+    )

--- a/pkgdb2/lib/model/__init__.py
+++ b/pkgdb2/lib/model/__init__.py
@@ -304,7 +304,7 @@ class PackageListingAcl(BASE):
     __tablename__ = 'PackageListingAcl'
 
     id = sa.Column(sa.Integer, primary_key=True)
-    fas_name = sa.Column(sa.String(32), nullable=False, index=True)
+    fas_name = sa.Column(sa.String(255), nullable=False, index=True)
     packagelisting_id = sa.Column(
         sa.Integer,
         sa.ForeignKey(


### PR DESCRIPTION
FAS restrict usernames to 32 characters, so we took the same approach
and restricted our usernames to 32 characters but that was without
thinking about the groups which do not have that restriction on their
names. So far we were lucky but apparently it's time to take it into
account.