### PR TITLE
Ensure the `rpms` namespace is always the first in the list (default)

### DIFF
--- a/pkgdb2/ui/packages.py
+++ b/pkgdb2/ui/packages.py
@@ -1361,6 +1361,10 @@ def package_request_new():
         collections.append(collection)
 
     namespaces = pkgdblib.get_status(SESSION, 'namespaces')['namespaces']
+    # Ensure the `rpms` namespace is always the first in the list (the default)
+    if 'rpms' in namespaces:
+        namespaces.pop(namespaces.index('rpms'))
+        namespaces.insert(0, 'rpms')
 
     form = pkgdb2.forms.RequestPackageForm(
         collections=collections,

--- a/pkgdb2/ui/packages.py
+++ b/pkgdb2/ui/packages.py
@@ -1361,10 +1361,11 @@ def package_request_new():
         collections.append(collection)
 
     namespaces = pkgdblib.get_status(SESSION, 'namespaces')['namespaces']
+    default_ns = APP.config.get('DEFAULT_NAMESPACE', 'rpms')
     # Ensure the `rpms` namespace is always the first in the list (the default)
-    if 'rpms' in namespaces:
-        namespaces.pop(namespaces.index('rpms'))
-        namespaces.insert(0, 'rpms')
+    if default_ns in namespaces:
+        namespaces.pop(namespaces.index(default_ns))
+        namespaces.insert(0, default_ns)
 
     form = pkgdb2.forms.RequestPackageForm(
         collections=collections,


### PR DESCRIPTION
Fixes https://github.com/fedora-infra/pkgdb2/issues/375