### PR TITLE
Added Support for dev environment under Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ doc/_build/
 start-pkgdb
 .coverage
 alembic.ini
+.vagrant/

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ pkgdb2 repo is super simple.
 First, install Vagrant and the vagrant-libvirt plugin from the official Fedora
 repos::
 
-    $ sudo yum install vagrant vagrant-libvirt
+    $ sudo dnf install vagrant vagrant-libvirt
 
 The pkgdb2 vagrant setup uses vagrant-sshfs for syncing files between your host
 and the vagrant dev machine. vagrant-sshfs is not in the Fedora repos (yet), so
@@ -49,7 +49,7 @@ into your dev VM with ``vagrant ssh`` and then run the command to start the
 pkgdb2 server::
 
     $ vagrant ssh
-    [vagrant@localhost ~]$ pushd /vagrant/; ./runserver.py -c pkgdb2/vagrant_default_config.py --host \"0.0.0.0\";
+    [vagrant@localhost ~]$ pushd /vagrant/; ./runserver.py -c pkgdb2/vagrant_default_config.py --host "0.0.0.0";
 
 Once that is running, simply go to http://localhost:5001/ in your browser on
 your host to see your running pkgdb2 test instance.

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,43 @@ bugzilla and who get the notifications for changes in the git, builds or bugs.
 
 
 Hacking
--------
+=======
+
+Hacking with Vagrant
+--------------------
+Quickly start hacking on pkgdb2 using the vagrant setup that is included in the
+pkgdb2 repo is super simple.
+
+First, install Vagrant and the vagrant-libvirt plugin from the official Fedora
+repos::
+
+    $ sudo yum install vagrant vagrant-libvirt
+
+The pkgdb2 vagrant setup uses vagrant-sshfs for syncing files between your host
+and the vagrant dev machine. vagrant-sshfs is not in the Fedora repos (yet), so
+we install the vagrant-sshfs plugin from dustymabe's COPR repo::
+
+    $ sudo dnf copr enable dustymabe/vagrant-sshfs
+    $ sudo dnf install vagrant-sshfs
+
+Now, from within main directory (the one with the Vagrantfile in it) of your git
+checkout of pkgdb, run the ``vagrant up`` command to provision your dev
+environment::
+
+    $ vagrant up
+
+When this command is completed (it may take a while) you will be able to ssh
+into your dev VM with ``vagrant ssh`` and then run the command to start the
+pkgdb2 server::
+
+    $ vagrant ssh
+    [vagrant@localhost ~]$ pushd /vagrant/; ./runserver.py -c pkgdb2/vagrant_default_config.py --host \"0.0.0.0\";
+
+Once that is running, simply go to http://localhost:5001/ in your browser on
+your host to see your running pkgdb2 test instance.
+
+Setting up a Dev Environment by hand
+------------------------------------
 
 Here are some preliminary instructions about how to stand up your own instance
 of packagedb2.  We'll use a virtualenv and a sqlite database and we'll install
@@ -33,7 +69,7 @@ First, set up a virtualenv::
     $ virtualenv my-pkgdb2-env
     $ source my-pkgdb2-env/bin/activate
 
-Issueing that last command should change your prompt to indicate that you are
+Issuing that last command should change your prompt to indicate that you are
 operating in an active virtualenv.
 
 Next, install your dependencies::
@@ -68,7 +104,7 @@ pkgdb2::
     (my-pkgdb2-env)$ python createdb.py
 
 Setting up PostgreSQL
-=====================
+~~~~~~~~~~~~~~~~~~~~~
 
 Using PostgreSQL is optional but if you want to work with real datadump then
 setting up PostgreSQL will be a better option

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/23/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-23-20151030.x86_64.vagrant-libvirt.box"
+  config.vm.box = "f23-cloud-libvirt"
+  config.vm.network "forwarded_port", guest: 5000, host: 5001
+  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
+
+  config.vm.provision "shell", inline: "sudo dnf -y install python redhat-rpm-config python-devel postgresql-devel postgresql-server rpl python-alembic python-psycopg2 gcc"
+
+  config.vm.provision "shell", inline: "pip install kitchen paver urllib3"
+  config.vm.provision "shell", inline: "pip install -r /vagrant/requirements.txt"
+
+  config.vm.provision "shell", inline: "sudo postgresql-setup initdb"
+
+  config.vm.provision "shell", inline: "sudo rpl 'host    all             all             127.0.0.1/32            ident' 'host    all             all             127.0.0.1/32            trust' /var/lib/pgsql/data/pg_hba.conf"
+  config.vm.provision "shell", inline: "sudo rpl 'host    all             all             ::1/128                 ident' 'host    all             all             ::1/128                 trust' /var/lib/pgsql/data/pg_hba.conf"
+
+  config.vm.provision "shell", inline: "sudo systemctl enable postgresql.service"
+  config.vm.provision "shell", inline: "sudo systemctl start postgresql.service"
+
+  config.vm.provision "shell", inline: "pushd /tmp/; curl -O https://infrastructure.fedoraproject.org/infra/db-dumps/pkgdb2.dump.xz; popd;"
+  config.vm.provision "shell", inline: "sudo runuser -l postgres -c 'createdb pkgdb2'"
+
+  config.vm.provision "shell", inline: "xzcat /tmp/pkgdb2.dump.xz | sudo runuser -l postgres -c 'psql pkgdb2'"
+
+  # Set up development.ini
+  config.vm.provision "shell", inline: "cp /vagrant/pkgdb2/default_config.py /vagrant/pkgdb2/vagrant_default_config.py", privileged: false
+  config.vm.provision "shell", inline: "pushd /vagrant/; rpl 'sqlite:////var/tmp/pkgdb2_dev.sqlite' 'postgresql://postgres:whatever@localhost/pkgdb2' /vagrant/pkgdb2/vagrant_default_config.py; popd;"
+  config.vm.provision "shell", inline: "echo 'Provisioning Complete. Connect to your new vagrant box with'"
+  config.vm.provision "shell", inline: "echo 'vagrant ssh'"
+  config.vm.provision "shell", inline: "echo 'Then start the pkdb2 server with'"
+  config.vm.provision "shell", inline: "echo 'pushd /vagrant/; ./runserver.py -c pkgdb2/vagrant_default_config.py --host \"0.0.0.0\";'"
+ 
+
+end
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,11 +28,8 @@ Vagrant.configure(2) do |config|
   # Set up development.ini
   config.vm.provision "shell", inline: "cp /vagrant/pkgdb2/default_config.py /vagrant/pkgdb2/vagrant_default_config.py", privileged: false
   config.vm.provision "shell", inline: "pushd /vagrant/; rpl 'sqlite:////var/tmp/pkgdb2_dev.sqlite' 'postgresql://postgres:whatever@localhost/pkgdb2' /vagrant/pkgdb2/vagrant_default_config.py; popd;"
-  config.vm.provision "shell", inline: "echo 'Provisioning Complete. Connect to your new vagrant box with'"
-  config.vm.provision "shell", inline: "echo 'vagrant ssh'"
-  config.vm.provision "shell", inline: "echo 'Then start the pkdb2 server with'"
-  config.vm.provision "shell", inline: "echo 'pushd /vagrant/; ./runserver.py -c pkgdb2/vagrant_default_config.py --host \"0.0.0.0\";'"
- 
+
+  config.vm.post_up_message = "Provisioning Complete. Connect to your new vagrant box with\nvagrant ssh\nThen start the pkdb2 server with\npushd /vagrant/; ./runserver.py -c pkgdb2/vagrant_default_config.py --host \"0.0.0.0\";\nYour fresh pkgdb2 instance will now be accessible at\nhttp://localhost:5001/"
 
 end
 

--- a/runserver.py
+++ b/runserver.py
@@ -25,6 +25,9 @@ parser.add_argument(
 parser.add_argument(
     '--port', '-p', default=5000,
     help='Port for the flask application.')
+parser.add_argument(
+    '--host', default="127.0.0.1",
+    help='Hostname to listen on. When set to 0.0.0.0 the server is available externally. Defaults to 127.0.0.1 making the it only visable on localhost')
 
 args = parser.parse_args()
 
@@ -42,4 +45,4 @@ if args.config:
 
 from pkgdb2 import APP
 APP.debug = True
-APP.run(port=int(args.port))
+APP.run(port=int(args.port), host=args.host)

--- a/runserver.py
+++ b/runserver.py
@@ -27,7 +27,8 @@ parser.add_argument(
     help='Port for the flask application.')
 parser.add_argument(
     '--host', default="127.0.0.1",
-    help='Hostname to listen on. When set to 0.0.0.0 the server is available externally. Defaults to 127.0.0.1 making the it only visable on localhost')
+    help='Hostname to listen on. When set to 0.0.0.0 the server is available \
+    externally. Defaults to 127.0.0.1 making the it only visable on localhost')
 
 args = parser.parse_args()
 


### PR DESCRIPTION
This adds a Vagrant file that allows a developer to quickly
set up a dev environment of pkgdb2 using the infra db dump.
It uses vagrant-libvirt and vagrantsshfs for file syncing.

Also in this change, added a new param in the runserver.py
that allows the host to be set as a commandline param.