### PR TITLE
Change vagrant provisioning to use ansible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ start-pkgdb
 .coverage
 alembic.ini
 .vagrant/
+devel/ansible/playbook.retry
+pkgdb2/vagrant_default_config.py

--- a/README.rst
+++ b/README.rst
@@ -26,10 +26,10 @@ Hacking with Vagrant
 Quickly start hacking on pkgdb2 using the vagrant setup that is included in the
 pkgdb2 repo is super simple.
 
-First, install Vagrant and the vagrant-libvirt plugin from the official Fedora
+First, install Ansible, Vagrant and the vagrant-libvirt plugin from the official Fedora
 repos::
 
-    $ sudo dnf install vagrant vagrant-libvirt
+    $ sudo dnf install ansible vagrant vagrant-libvirt
 
 The pkgdb2 vagrant setup uses vagrant-sshfs for syncing files between your host
 and the vagrant dev machine. vagrant-sshfs is not in the Fedora repos (yet), so

--- a/devel/ansible/playbook.yml
+++ b/devel/ansible/playbook.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  become: true
+  become_method: sudo
+  vars:
+  roles:
+    - core
+    - db
+    - dev

--- a/devel/ansible/roles/core/tasks/main.yml
+++ b/devel/ansible/roles/core/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Install basic packages
+  dnf:
+      name: "{{ item }}"
+      state: present
+  with_items:
+      - bash-completion
+      - dstat
+      - htop
+      - screen
+      - tmux
+      - tree

--- a/devel/ansible/roles/db/tasks/main.yml
+++ b/devel/ansible/roles/db/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Install database packages
+  dnf:
+      name: "{{ item }}"
+      state: present
+  with_items:
+      - postgresql-server
+
+- name: Initialize PostgreSQL
+  command: postgresql-setup initdb
+  args:
+      creates: /var/lib/pgsql/data/pg_hba.conf
+
+- replace:
+    dest: /var/lib/pgsql/data/pg_hba.conf
+    regexp: "host    all             all             127.0.0.1/32            ident"
+    replace: "host    all             all             127.0.0.1/32            trust"
+
+- replace:
+    dest: /var/lib/pgsql/data/pg_hba.conf
+    regexp: "host    all             all             ::1/128                 ident"
+    replace: "host    all             all             ::1/128                 trust"
+
+- service:
+    name: postgresql
+    state: started
+    enabled: yes
+
+- name: Create a database for Pkgdb2
+  shell: runuser -l postgres -c 'createdb pkgdb2' && touch /home/vagrant/.db-created
+  args:
+      creates: /home/vagrant/.db-created

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+- name: Install dev packages
+  dnf:
+      name: "{{ item }}"
+      state: present
+  with_items:
+      - gcc
+      - postgresql-devel
+      - python
+      - python-devel
+      - python-alembic
+      - python-psycopg2
+      - redhat-rpm-config
+
+- name: Install python packages
+  pip:
+      name: "{{ item }}"
+      state: present
+  with_items:
+      - kitchen
+      - paver
+      - urllib3
+
+- name: Install python packages from requirements.txt
+  pip:
+      requirements: /vagrant/requirements.txt
+
+- name: Retrieve database dump
+  get_url:
+      url: https://infrastructure.fedoraproject.org/infra/db-dumps/pkgdb2.dump.xz
+      dest: /tmp/pkgdb2.dump.xz
+
+- shell: xzcat /tmp/pkgdb2.dump.xz | runuser -l postgres -c 'psql pkgdb2' && touch /home/vagrant/.db-imported
+  args:
+      creates: /home/vagrant/.db-imported
+
+- command: cp /vagrant/pkgdb2/default_config.py /vagrant/pkgdb2/vagrant_default_config.py
+  args:
+    creates: /vagrant/pkgdb2/vagrant_default_config.py
+
+- replace:
+    dest: /vagrant/pkgdb2/vagrant_default_config.py
+    regexp: "sqlite:////var/tmp/pkgdb2_dev.sqlite"
+    replace: "postgresql://postgres:whatever@localhost/pkgdb2"


### PR DESCRIPTION
This changes the was we provision the vagrant devel
envrionment, from the shell provisioner to the ansible
one.

These changes are based heavily on the same work done by @bowlofeggs on bodhi in https://github.com/fedora-infra/bodhi/pull/893 