### PR TITLE
Specify rel="noopener noreferrer" to link including target='_blank'

### DIFF
--- a/pkgdb2/templates/master.html
+++ b/pkgdb2/templates/master.html
@@ -121,7 +121,7 @@
           Copyright &copy; 2013-2016 Red Hat
           <a href="https://fedorahosted.org/pkgdb2/">pkgdb2</a>
           -- {{version}}
-          -- <a href="http://pkgdb2.rtfd.org"
+          -- <a href="http://pkgdb2.rtfd.org" rel="noopener noreferrer"
                 target="_blank">Documentation</a>
           -- <a href="{{ url_for('api_ns.api') }}">API</a>
         </p>

--- a/pkgdb2/templates/package.html
+++ b/pkgdb2/templates/package.html
@@ -57,7 +57,7 @@ confusing what the difference is between that status an the per-branch status)
 
     <tr>
         <th>
-          <a target="_blank"
+          <a target="_blank" rel="noopener noreferrer"
           href="https://fedoraproject.org/wiki/Upstream_release_monitoring">
             Monitoring:
           </a>
@@ -120,7 +120,8 @@ confusing what the difference is between that status an the per-branch status)
     </tr>
     <tr>
         <th>
-          <a target="_blank" href="https://fedoraproject.org/wiki/Koschei">
+          <a target="_blank" href="https://fedoraproject.org/wiki/Koschei"
+             rel="noopener noreferrer">
             Koschei integration:
           </a>
         </th>

--- a/pkgdb2/templates/package_anitya.html
+++ b/pkgdb2/templates/package_anitya.html
@@ -33,7 +33,8 @@
 anitya</a>.
 </p>
 <p>
-  <a href="{{ config['PKGDB2_ANITYA_URL'] }}/project/new?name={{ package }}&amp;homepage={{ pkg.upstream_url }}&amp;distro=Fedora&amp;package_name={{ package }}" target="_blank">
+  <a href="{{ config['PKGDB2_ANITYA_URL'] }}/project/new?name={{ package }}&amp;homepage={{ pkg.upstream_url }}&amp;distro=Fedora&amp;package_name={{ package }}"
+    target="_blank" rel="noopener noreferrer">
     Add it yourself!
   </a>
 </p>

--- a/pkgdb2/templates/packager.html
+++ b/pkgdb2/templates/packager.html
@@ -9,7 +9,7 @@
 <span class="inline">
 <h1>
   {{ packager | avatar | safe }}
-  {{ packager }}</h1> (<a class="fas" target="_blank"
+  {{ packager }}</h1> (<a class="fas" target="_blank" rel="noopener noreferrer"
     {% if packager.startswith('group::') %}
         href="{{ config['PKGDB2_FAS_URL'] }}/group/view/{{ packager.replace('group::', '') }}"
     {% else %}


### PR DESCRIPTION
This avoids potential security risk:
https://dev.to/ben/the-targetblank-vulnerability-by-example
https://mathiasbynens.github.io/rel-noopener/