### PR TITLE
update vagrant ansible role to upgrade database

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -42,3 +42,17 @@
     dest: /vagrant/pkgdb2/vagrant_default_config.py
     regexp: "sqlite:////var/tmp/pkgdb2_dev.sqlite"
     replace: "postgresql://postgres:whatever@localhost/pkgdb2"
+
+- command: cp /vagrant/utility/alembic.ini /vagrant/alembic.ini
+  args:
+    creates: /vagrant/alembic.ini
+
+- replace:
+    dest: /vagrant/alembic.ini
+    regexp: "driver://user:pass@localhost/dbname"
+    replace: "postgresql://postgres:whatever@localhost/pkgdb2"
+
+- name: Apply database migrations
+  command: alembic upgrade head
+  args:
+        chdir: /vagrant


### PR DESCRIPTION
Previously, the vagrant config did not upgrade the database
when provisioning the new machine. This could lead to issues
if a database change was commited to master, and we pull the
dbdump from prod.

This change copies the alembic.ini from the utility directory,
changes the dburl to what the vagrant setup expects, and runs
the alembic upgrade command.