### PR TITLE
Fix bug title splitting

### DIFF
--- a/pkgdb2/api/extras.py
+++ b/pkgdb2/api/extras.py
@@ -795,7 +795,7 @@ def api_pkgrequest(bzid):
         else:
             output['error'] = msg
 
-    tmp = bug.summary.partition(':')[1]
+    tmp = bug.summary.partition(':')[2]
     if not tmp:
         httpcode = 400
         output['output'] = 'notok'


### PR DESCRIPTION
tmp was just the :, due to the partition(':')[1].

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>