### PR TITLE
Fix approving a new package request in the docker namespace

### DIFF
--- a/pkgdb2/lib/__init__.py
+++ b/pkgdb2/lib/__init__.py
@@ -2715,13 +2715,14 @@ def edit_action_status(
         if action_status == 'Approved' \
                 and admin_action.action == 'request.package':
             pkg = admin_action.info_data.get('pkg_name')
+            namespace = admin_action.info_data.get('pkg_namespace', 'rpms')
             if pkg:
                 requests = search_actions(
-                    session, package=pkg, action='request.package',
-                    status='Awaiting Review')
+                    session, package=pkg, namespace=namespace,
+                    action='request.package', status='Awaiting Review')
                 requests.extend(search_actions(
-                    session, package=pkg, action='request.branch',
-                    status='Awaiting Review'))
+                    session, package=pkg, namespace=namespace,
+                    action='request.branch', status='Awaiting Review'))
                 for req in requests:
                     if req.collection.name.lower() != 'fedora':
                         continue
@@ -2730,6 +2731,7 @@ def edit_action_status(
                         set_acl_package(
                             session,
                             pkg_name=pkg,
+                            namespace=namespace,
                             pkg_branch=req.collection.branchname,
                             pkg_user=user.username,
                             acl=acl,


### PR DESCRIPTION
When we approve a new package request, in any namespace, we normally go
then through all the other pending requests to automatically create the
branch (for the branches for which we can).
With non-rpm namespaces, this logic was broken since we were not including
the namespace in the search for other requests and we were ending up
with an exception saying that there are no such package.
This was confusing when processing the requests via pkgdb-admin since it
would return an error (not even a clear one) and then when checking the
UI, the new package was created.

This commit fixes that situation.