### PR TITLE
Fix running the query on postgresql

### DIFF
--- a/pkgdb2/lib/model/__init__.py
+++ b/pkgdb2/lib/model/__init__.py
@@ -2058,7 +2058,7 @@ def notify(session, eol=False, name=None, version=None, acls=None):
     ).filter(
         PackageListingAcl.status == 'Approved'
     ).group_by(
-        Package.name, PackageListingAcl.fas_name
+        Package.name, PackageListingAcl.fas_name, Package.id
     ).order_by(
         Package.namespace,
         Package.name,


### PR DESCRIPTION
The identifier must be part of the group_by on postgresql otherwise
it fails.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>